### PR TITLE
Add Claude Code automations: CLAUDE.md, pyright hook, HACS reviewer

### DIFF
--- a/.claude/agents/hacs-reviewer.md
+++ b/.claude/agents/hacs-reviewer.md
@@ -1,0 +1,46 @@
+You are a HACS compliance reviewer for a Home Assistant custom integration.
+
+## Checks to Perform
+
+### 1. hacs.json
+
+Verify required fields are present and valid:
+
+- `name` (string)
+- `homeassistant` (valid version string, e.g. "2024.8.0")
+- `render_readme` (boolean)
+
+### 2. manifest.json (`custom_components/rutos/manifest.json`)
+
+Verify required keys:
+
+- `domain`, `name`, `version`, `documentation`, `issue_tracker`
+- `codeowners` (non-empty list)
+- `requirements` (list)
+- `iot_class`
+- `version` follows semver (e.g. "1.2.3", no "v" prefix)
+
+### 3. Translations (`custom_components/rutos/translations/en.json`)
+
+- File exists and is valid JSON
+- All steps and fields referenced in `config_flow.py` have corresponding entries
+- No orphaned translation keys (keys with no matching config flow usage)
+
+### 4. Brand Assets
+
+- Check for icon/logo files or brand references
+- Verify any referenced brand assets exist
+
+### 5. Repository Hygiene
+
+- No `__pycache__` directories in tracked files
+- No `.pyc` files in tracked files
+- `.gitignore` excludes common Python artifacts
+
+## Output
+
+Provide a checklist-style report:
+
+- ✅ Passing checks with brief confirmation
+- ❌ Failing checks with specific file, line, and remediation
+- ⚠️ Warnings for non-blocking issues

--- a/.claude/hooks/typecheck.sh
+++ b/.claude/hooks/typecheck.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path')
+
+# Only type-check Python files
+echo "$FILE_PATH" | grep -qE '\.py$' || exit 0
+
+/opt/homebrew/bin/pyright "$FILE_PATH" 2>/dev/null
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -25,6 +25,11 @@
             "type": "command",
             "command": ".claude/hooks/lint.sh",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/typecheck.sh",
+            "timeout": 30
           }
         ]
       },
@@ -40,6 +45,11 @@
             "type": "command",
             "command": ".claude/hooks/lint.sh",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/typecheck.sh",
+            "timeout": 30
           }
         ]
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,50 @@
+# ha-rutos-integration
+
+Home Assistant custom integration for Teltonika RutOS routers, distributed via
+HACS.
+
+## Key Paths
+
+- `custom_components/rutos/` — integration source
+- `tests/` — pytest test suite
+- `hacs.json` — HACS repository metadata
+- `custom_components/rutos/manifest.json` — HA integration manifest
+- `custom_components/rutos/translations/en.json` — UI strings
+
+## Dev Commands
+
+- **Test:** `python -m pytest tests/ -v`
+- **Lint:** `ruff check custom_components/rutos/`
+- **Format:** `ruff format custom_components/rutos/`
+- **Type-check:** `/opt/homebrew/bin/pyright custom_components/rutos/`
+- **HACS validate:**
+  `docker run --rm -v $(pwd):/github/workspace ghcr.io/hacs/action`
+
+## Conventions
+
+- All entities inherit from `RutOSEntity` base class (`entity.py`) which
+  provides shared `device_info` and interface lookup logic. Do not duplicate
+  this in platform files.
+- Follow Home Assistant integration patterns: `async_setup_entry` /
+  `async_unload_entry`, `DataUpdateCoordinator`, `ConfigFlow`.
+- Use `aiohttp` for async HTTP (via `homeassistant.helpers.aiohttp_client`),
+  never `requests`.
+- Config flow strings must stay in sync between `config_flow.py` and
+  `translations/en.json`.
+- Sensor/binary_sensor/switch descriptions use `EntityDescription` dataclasses.
+
+## Code Navigation — Prefer Serena MCP Tools
+
+When exploring or reading code in this project, **prefer Serena MCP tools** over
+Read/Grep/Glob:
+
+- `get_symbols_overview` — get a file's classes, functions, and methods without
+  reading the full file
+- `find_symbol` — locate a symbol by name path (e.g. `RutOSEntity/device_info`),
+  optionally with `include_body=True`
+- `find_referencing_symbols` — find all callers/users of a symbol before
+  modifying it
+- `search_for_pattern` — fast regex search across the codebase
+
+Only fall back to Read/Grep/Glob when working with non-code files (JSON, YAML,
+markdown) or when you need raw file content that isn't organized into symbols.


### PR DESCRIPTION
## Summary

- Add `CLAUDE.md` project context file with key paths, conventions, and instruction to prefer Serena MCP tools for code navigation
- Add pyright type-check PostToolUse hook (`.claude/hooks/typecheck.sh`) alongside existing format/lint hooks
- Add HACS compliance reviewer agent (`.claude/agents/hacs-reviewer.md`) for validating hacs.json, manifest, translations, brand assets, and repo hygiene
- Update `.claude/settings.json` to wire typecheck hook into both Write and Edit matchers

## Test plan

- [ ] Verify `CLAUDE.md` is loaded in new Claude Code sessions
- [ ] Edit a `.py` file and confirm pyright hook runs after format and lint
- [ ] Run the HACS reviewer agent and verify it produces a compliance checklist
- [ ] Confirm `settings.json` is valid JSON with 3 hooks per PostToolUse matcher

🤖 Generated with [Claude Code](https://claude.com/claude-code)