### PR TITLE
Add cellular signal strength sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ failover control.
 - **WAN Interface Switches** — Enable/disable individual WAN interfaces
 - **Failover Ordering** — Service call to reorder WAN interface failover
   priority
+- **Cellular Signal** — RSSI, RSRP, RSRQ, SINR, network type, and band for each
+  modem
 
 ## Installation
 

--- a/custom_components/rutos/api.py
+++ b/custom_components/rutos/api.py
@@ -244,6 +244,33 @@ class RutOSAPI:
             {"data": {"enabled": "1" if enabled else "0"}},
         )
 
+    async def get_modem_signal(self) -> list[dict[str, Any]]:
+        """Fetch signal strength data for all modems."""
+        try:
+            data = await self.get("/modems/signal/status")
+        except RutOSAPIError:
+            return []
+
+        if not isinstance(data, list):
+            return []
+
+        modems: list[dict[str, Any]] = []
+        for modem in data:
+            if not isinstance(modem, dict):
+                continue
+            modem_id = modem.get("id", "")
+            modems.append({
+                "id": modem_id,
+                "rssi": modem.get("rssi"),
+                "rsrp": modem.get("rsrp"),
+                "rsrq": modem.get("rsrq"),
+                "sinr": modem.get("sinr"),
+                "network_type": modem.get("network_type"),
+                "band": modem.get("band"),
+                "channel_number": modem.get("channel_number"),
+            })
+        return modems
+
     async def set_failover_order(self, interfaces: list[str]) -> None:
         """Set the failover order by updating interface metrics."""
         for idx, iface_id in enumerate(interfaces):

--- a/custom_components/rutos/coordinator.py
+++ b/custom_components/rutos/coordinator.py
@@ -24,6 +24,7 @@ class RutOSData:
     device_info: dict[str, Any] = field(default_factory=dict)
     wan_interfaces: list[dict[str, Any]] = field(default_factory=list)
     internet_available: bool = False
+    modem_signal: list[dict[str, Any]] = field(default_factory=list)
 
 
 class RutOSDataUpdateCoordinator(DataUpdateCoordinator[RutOSData]):
@@ -58,9 +59,12 @@ class RutOSDataUpdateCoordinator(DataUpdateCoordinator[RutOSData]):
             self.data = RutOSData()
 
         try:
-            wan_interfaces, internet_available = await asyncio.gather(
-                self.api.get_wan_interfaces(),
-                self.api.get_internet_status(),
+            wan_interfaces, internet_available, modem_signal = (
+                await asyncio.gather(
+                    self.api.get_wan_interfaces(),
+                    self.api.get_internet_status(),
+                    self.api.get_modem_signal(),
+                )
             )
         except RutOSAuthError as err:
             raise UpdateFailed(f"Authentication failed: {err}") from err
@@ -69,4 +73,5 @@ class RutOSDataUpdateCoordinator(DataUpdateCoordinator[RutOSData]):
 
         self.data.wan_interfaces = wan_interfaces
         self.data.internet_available = internet_available
+        self.data.modem_signal = modem_signal
         return self.data

--- a/custom_components/rutos/sensor.py
+++ b/custom_components/rutos/sensor.py
@@ -6,7 +6,12 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
-from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -19,7 +24,7 @@ from .entity import RutOSEntity
 class RutOSSensorEntityDescription(SensorEntityDescription):
     """Describe a RutOS sensor entity."""
 
-    value_fn: Callable[[dict[str, Any]], str | int | None]
+    value_fn: Callable[[dict[str, Any]], str | int | float | None]
 
 
 INTERFACE_SENSORS: tuple[RutOSSensorEntityDescription, ...] = (
@@ -47,6 +52,50 @@ INTERFACE_SENSORS: tuple[RutOSSensorEntityDescription, ...] = (
 )
 
 
+MODEM_SIGNAL_SENSORS: tuple[RutOSSensorEntityDescription, ...] = (
+    RutOSSensorEntityDescription(
+        key="rssi",
+        translation_key="modem_rssi",
+        native_unit_of_measurement="dBm",
+        device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda m: m.get("rssi"),
+    ),
+    RutOSSensorEntityDescription(
+        key="rsrp",
+        translation_key="modem_rsrp",
+        native_unit_of_measurement="dBm",
+        device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda m: m.get("rsrp"),
+    ),
+    RutOSSensorEntityDescription(
+        key="rsrq",
+        translation_key="modem_rsrq",
+        native_unit_of_measurement="dB",
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda m: m.get("rsrq"),
+    ),
+    RutOSSensorEntityDescription(
+        key="sinr",
+        translation_key="modem_sinr",
+        native_unit_of_measurement="dB",
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda m: m.get("sinr"),
+    ),
+    RutOSSensorEntityDescription(
+        key="network_type",
+        translation_key="modem_network_type",
+        value_fn=lambda m: m.get("network_type"),
+    ),
+    RutOSSensorEntityDescription(
+        key="band",
+        translation_key="modem_band",
+        value_fn=lambda m: m.get("band"),
+    ),
+)
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -54,11 +103,19 @@ async def async_setup_entry(
 ) -> None:
     """Set up RutOS sensors based on a config entry."""
     coordinator: RutOSDataUpdateCoordinator = entry.runtime_data
-    async_add_entities([
+    entities: list[SensorEntity] = [
         RutOSSensorEntity(coordinator, description, iface["name"])
         for iface in coordinator.data.wan_interfaces
         for description in INTERFACE_SENSORS
-    ] + [RutOSActiveWANSensor(coordinator)])
+    ]
+    entities.append(RutOSActiveWANSensor(coordinator))
+    for modem in coordinator.data.modem_signal:
+        modem_id = modem.get("id", "")
+        entities.extend(
+            RutOSModemSignalSensor(coordinator, desc, modem_id)
+            for desc in MODEM_SIGNAL_SENSORS
+        )
+    async_add_entities(entities)
 
 
 class RutOSSensorEntity(RutOSEntity, SensorEntity):
@@ -82,12 +139,48 @@ class RutOSSensorEntity(RutOSEntity, SensorEntity):
         self._attr_translation_placeholders = {"interface": interface_name}
 
     @property
-    def native_value(self) -> str | int | None:
+    def native_value(self) -> str | int | float | None:
         """Return the sensor value."""
         iface = self._find_interface(self._interface_name)
         if iface is None:
             return None
         return self.entity_description.value_fn(iface)
+
+
+class RutOSModemSignalSensor(RutOSEntity, SensorEntity):
+    """Representation of a RutOS modem signal sensor."""
+
+    entity_description: RutOSSensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: RutOSDataUpdateCoordinator,
+        description: RutOSSensorEntityDescription,
+        modem_id: str,
+    ) -> None:
+        """Initialize the modem signal sensor."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._modem_id = modem_id
+        self._attr_unique_id = (
+            f"{coordinator.data.device_info.get('serial', '')}_{modem_id}_{description.key}"
+        )
+        self._attr_translation_placeholders = {"modem": modem_id}
+
+    def _find_modem(self) -> dict[str, Any] | None:
+        """Find modem data by id."""
+        for modem in self.coordinator.data.modem_signal:
+            if modem.get("id") == self._modem_id:
+                return modem
+        return None
+
+    @property
+    def native_value(self) -> str | int | float | None:
+        """Return the sensor value."""
+        modem = self._find_modem()
+        if modem is None:
+            return None
+        return self.entity_description.value_fn(modem)
 
 
 class RutOSActiveWANSensor(RutOSEntity, SensorEntity):

--- a/custom_components/rutos/translations/en.json
+++ b/custom_components/rutos/translations/en.json
@@ -36,6 +36,24 @@
       },
       "active_wan": {
         "name": "Active WAN interface"
+      },
+      "modem_rssi": {
+        "name": "{modem} RSSI"
+      },
+      "modem_rsrp": {
+        "name": "{modem} RSRP"
+      },
+      "modem_rsrq": {
+        "name": "{modem} RSRQ"
+      },
+      "modem_sinr": {
+        "name": "{modem} SINR"
+      },
+      "modem_network_type": {
+        "name": "{modem} network type"
+      },
+      "modem_band": {
+        "name": "{modem} band"
       }
     },
     "binary_sensor": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,12 +63,30 @@ def mock_wan_interfaces() -> list[dict]:
 
 
 @pytest.fixture
-def mock_rutos_data(mock_device_info, mock_wan_interfaces) -> RutOSData:
+def mock_modem_signal() -> list[dict]:
+    """Return mock modem signal data."""
+    return [
+        {
+            "id": "modem1",
+            "rssi": -65,
+            "rsrp": -95,
+            "rsrq": -10,
+            "sinr": 12,
+            "network_type": "LTE",
+            "band": "B7",
+            "channel_number": 3100,
+        },
+    ]
+
+
+@pytest.fixture
+def mock_rutos_data(mock_device_info, mock_wan_interfaces, mock_modem_signal) -> RutOSData:
     """Return a populated RutOSData instance."""
     return RutOSData(
         device_info=mock_device_info,
         wan_interfaces=mock_wan_interfaces,
         internet_available=True,
+        modem_signal=mock_modem_signal,
     )
 
 
@@ -80,6 +98,18 @@ def mock_api(mock_device_info, mock_wan_interfaces) -> AsyncMock:
     api.get_device_info.return_value = mock_device_info
     api.get_wan_interfaces.return_value = mock_wan_interfaces
     api.get_internet_status.return_value = True
+    api.get_modem_signal.return_value = [
+        {
+            "id": "modem1",
+            "rssi": -65,
+            "rsrp": -95,
+            "rsrq": -10,
+            "sinr": 12,
+            "network_type": "LTE",
+            "band": "B7",
+            "channel_number": 3100,
+        },
+    ]
     api.set_interface_enabled.return_value = None
     api.set_failover_order.return_value = None
     return api

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -662,3 +662,62 @@ class TestGetInternetStatusVariants:
             )
 
             assert await api_client.get_internet_status() is True
+
+
+class TestGetModemSignal:
+    """Tests for get_modem_signal."""
+
+    async def test_get_modem_signal_success(self, api_client):
+        """Test parsing of modem signal response."""
+        signal_data = [
+            {
+                "id": "modem1",
+                "rssi": -65,
+                "rsrp": -95,
+                "rsrq": -10,
+                "sinr": 12,
+                "network_type": "LTE",
+                "band": "B7",
+                "channel_number": 3100,
+            },
+        ]
+        with aioresponses() as m:
+            m.post(_url("/login"), payload=_login_success())
+            m.get(_url("/modems/signal/status"), payload=_success(signal_data))
+
+            result = await api_client.get_modem_signal()
+
+            assert len(result) == 1
+            assert result[0]["id"] == "modem1"
+            assert result[0]["rsrp"] == -95
+            assert result[0]["network_type"] == "LTE"
+
+    async def test_get_modem_signal_empty(self, api_client):
+        """Test returns empty list when no modems."""
+        with aioresponses() as m:
+            m.post(_url("/login"), payload=_login_success())
+            m.get(_url("/modems/signal/status"), payload=_success([]))
+
+            result = await api_client.get_modem_signal()
+            assert result == []
+
+    async def test_get_modem_signal_api_error(self, api_client):
+        """Test returns empty list on API error."""
+        with aioresponses() as m:
+            m.post(_url("/login"), payload=_login_success())
+            m.get(
+                _url("/modems/signal/status"),
+                payload=_error("Service unavailable"),
+            )
+
+            result = await api_client.get_modem_signal()
+            assert result == []
+
+    async def test_get_modem_signal_non_list(self, api_client):
+        """Test returns empty list for non-list response."""
+        with aioresponses() as m:
+            m.post(_url("/login"), payload=_login_success())
+            m.get(_url("/modems/signal/status"), payload=_success({"unexpected": True}))
+
+            result = await api_client.get_modem_signal()
+            assert result == []

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -64,8 +64,11 @@ async def test_async_update_data_returns_rutos_data(
     assert isinstance(result, RutOSData)
     assert result.wan_interfaces == mock_wan_interfaces
     assert result.internet_available is True
+    assert len(result.modem_signal) == 1
+    assert result.modem_signal[0]["id"] == "modem1"
     mock_api.get_wan_interfaces.assert_awaited_once()
     mock_api.get_internet_status.assert_awaited_once()
+    mock_api.get_modem_signal.assert_awaited_once()
 
 
 async def test_async_update_data_auth_error_raises_update_failed(
@@ -125,3 +128,4 @@ async def test_async_update_data_initializes_data_when_none(
 
     assert isinstance(result, RutOSData)
     assert result.wan_interfaces == mock_wan_interfaces
+    assert len(result.modem_signal) == 1

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -70,6 +70,7 @@ def mock_api_instance():
     api.get_device_info.return_value = MOCK_DEVICE_INFO
     api.get_wan_interfaces.return_value = MOCK_WAN_INTERFACES
     api.get_internet_status.return_value = True
+    api.get_modem_signal.return_value = []
     api.set_failover_order.return_value = None
     return api
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -12,7 +12,9 @@ from custom_components.rutos.const import DOMAIN
 from custom_components.rutos.coordinator import RutOSData, RutOSDataUpdateCoordinator
 from custom_components.rutos.sensor import (
     INTERFACE_SENSORS,
+    MODEM_SIGNAL_SENSORS,
     RutOSActiveWANSensor,
+    RutOSModemSignalSensor,
     RutOSSensorEntity,
 )
 
@@ -124,3 +126,71 @@ class TestRutOSActiveWANSensor:
         """Test unique_id is {serial}_active_wan."""
         sensor = RutOSActiveWANSensor(mock_coordinator)
         assert sensor.unique_id == "1234567890_active_wan"
+
+
+class TestRutOSModemSignalSensor:
+    """Tests for modem signal sensor entities."""
+
+    def test_rssi_value(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Test RSSI sensor returns signal strength."""
+        desc = MODEM_SIGNAL_SENSORS[0]  # rssi
+        sensor = RutOSModemSignalSensor(mock_coordinator, desc, "modem1")
+        assert sensor.native_value == -65
+
+    def test_rsrp_value(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Test RSRP sensor returns reference signal power."""
+        desc = MODEM_SIGNAL_SENSORS[1]  # rsrp
+        sensor = RutOSModemSignalSensor(mock_coordinator, desc, "modem1")
+        assert sensor.native_value == -95
+
+    def test_rsrq_value(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Test RSRQ sensor returns reference signal quality."""
+        desc = MODEM_SIGNAL_SENSORS[2]  # rsrq
+        sensor = RutOSModemSignalSensor(mock_coordinator, desc, "modem1")
+        assert sensor.native_value == -10
+
+    def test_sinr_value(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Test SINR sensor returns signal-to-noise ratio."""
+        desc = MODEM_SIGNAL_SENSORS[3]  # sinr
+        sensor = RutOSModemSignalSensor(mock_coordinator, desc, "modem1")
+        assert sensor.native_value == 12
+
+    def test_network_type_value(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Test network type sensor returns LTE/5G etc."""
+        desc = MODEM_SIGNAL_SENSORS[4]  # network_type
+        sensor = RutOSModemSignalSensor(mock_coordinator, desc, "modem1")
+        assert sensor.native_value == "LTE"
+
+    def test_band_value(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Test band sensor returns band identifier."""
+        desc = MODEM_SIGNAL_SENSORS[5]  # band
+        sensor = RutOSModemSignalSensor(mock_coordinator, desc, "modem1")
+        assert sensor.native_value == "B7"
+
+    def test_missing_modem_returns_none(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Test returns None when modem not found."""
+        desc = MODEM_SIGNAL_SENSORS[0]
+        sensor = RutOSModemSignalSensor(mock_coordinator, desc, "nonexistent")
+        assert sensor.native_value is None
+
+    def test_unique_id_format(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Test unique_id follows {serial}_{modem}_{key} pattern."""
+        desc = MODEM_SIGNAL_SENSORS[0]
+        sensor = RutOSModemSignalSensor(mock_coordinator, desc, "modem1")
+        assert sensor.unique_id == "1234567890_modem1_rssi"


### PR DESCRIPTION
## Summary
- Adds per-modem sensors for RSSI, RSRP, RSRQ, SINR, network type, and band
- Signal data fetched from `GET /modems/signal/status` in parallel with existing polls
- Sensors dynamically created per detected modem with `{modem}` name placeholders
- Gracefully returns empty list when no modems or API unavailable

## Test plan
- [x] API tests: success, empty, API error, non-list response
- [x] Sensor tests: all 6 signal metrics, missing modem returns None, unique IDs
- [x] Coordinator tests: modem signal data included in parallel fetch
- [x] All 95 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)