### PR TITLE
Add mobile data usage and limit sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ failover control.
 - **WAN Interface Switches** — Enable/disable individual WAN interfaces
 - **Failover Ordering** — Service call to reorder WAN interface failover
   priority
+- **Data Usage** — Data used, data limit, and usage percentage for each
+  configured data limit, plus a button to reset usage counters
 
 ## Installation
 

--- a/custom_components/rutos/__init__.py
+++ b/custom_components/rutos/__init__.py
@@ -28,6 +28,7 @@ PLATFORMS: list[Platform] = [
     Platform.SENSOR,
     Platform.BINARY_SENSOR,
     Platform.SWITCH,
+    Platform.BUTTON,
 ]
 
 type RutOSConfigEntry = ConfigEntry[RutOSDataUpdateCoordinator]

--- a/custom_components/rutos/api.py
+++ b/custom_components/rutos/api.py
@@ -244,6 +244,36 @@ class RutOSAPI:
             {"data": {"enabled": "1" if enabled else "0"}},
         )
 
+    async def get_data_limit(self) -> list[dict[str, Any]]:
+        """Fetch data limit/usage status for all configured limits."""
+        try:
+            data = await self.get("/data_limit/status")
+        except RutOSAPIError:
+            return []
+
+        if not isinstance(data, list):
+            return []
+
+        limits: list[dict[str, Any]] = []
+        for entry in data:
+            if not isinstance(entry, dict):
+                continue
+            limits.append({
+                "id": entry.get("id", ""),
+                "interface": entry.get("interface", ""),
+                "enabled": entry.get("enabled", False),
+                "data_limit": entry.get("data_limit", 0),
+                "data_used": entry.get("data_used", 0),
+                "data_warning_enabled": entry.get("data_warning_enabled", False),
+                "data_warning_limit": entry.get("data_warning_limit", 0),
+                "due_reset_time": entry.get("due_reset_time"),
+            })
+        return limits
+
+    async def clear_data_usage(self) -> None:
+        """Clear/reset data usage counters."""
+        await self.post("/data_limit/actions/clear")
+
     async def set_failover_order(self, interfaces: list[str]) -> None:
         """Set the failover order by updating interface metrics."""
         for idx, iface_id in enumerate(interfaces):

--- a/custom_components/rutos/button.py
+++ b/custom_components/rutos/button.py
@@ -1,0 +1,40 @@
+"""Button platform for the RutOS integration."""
+
+from __future__ import annotations
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .coordinator import RutOSDataUpdateCoordinator
+from .entity import RutOSEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up RutOS buttons based on a config entry."""
+    coordinator: RutOSDataUpdateCoordinator = entry.runtime_data
+    if coordinator.data.data_limit:
+        async_add_entities([RutOSClearDataUsageButton(coordinator)])
+
+
+class RutOSClearDataUsageButton(RutOSEntity, ButtonEntity):
+    """Button to clear/reset data usage counters."""
+
+    _attr_translation_key = "clear_data_usage"
+
+    def __init__(self, coordinator: RutOSDataUpdateCoordinator) -> None:
+        """Initialize the button."""
+        super().__init__(coordinator)
+        self._attr_unique_id = (
+            f"{coordinator.data.device_info.get('serial', '')}_clear_data_usage"
+        )
+
+    async def async_press(self) -> None:
+        """Handle the button press."""
+        await self.coordinator.api.clear_data_usage()
+        await self.coordinator.async_request_refresh()

--- a/custom_components/rutos/coordinator.py
+++ b/custom_components/rutos/coordinator.py
@@ -24,6 +24,7 @@ class RutOSData:
     device_info: dict[str, Any] = field(default_factory=dict)
     wan_interfaces: list[dict[str, Any]] = field(default_factory=list)
     internet_available: bool = False
+    data_limit: list[dict[str, Any]] = field(default_factory=list)
 
 
 class RutOSDataUpdateCoordinator(DataUpdateCoordinator[RutOSData]):
@@ -58,9 +59,12 @@ class RutOSDataUpdateCoordinator(DataUpdateCoordinator[RutOSData]):
             self.data = RutOSData()
 
         try:
-            wan_interfaces, internet_available = await asyncio.gather(
-                self.api.get_wan_interfaces(),
-                self.api.get_internet_status(),
+            wan_interfaces, internet_available, data_limit = (
+                await asyncio.gather(
+                    self.api.get_wan_interfaces(),
+                    self.api.get_internet_status(),
+                    self.api.get_data_limit(),
+                )
             )
         except RutOSAuthError as err:
             raise UpdateFailed(f"Authentication failed: {err}") from err
@@ -69,4 +73,5 @@ class RutOSDataUpdateCoordinator(DataUpdateCoordinator[RutOSData]):
 
         self.data.wan_interfaces = wan_interfaces
         self.data.internet_available = internet_available
+        self.data.data_limit = data_limit
         return self.data

--- a/custom_components/rutos/sensor.py
+++ b/custom_components/rutos/sensor.py
@@ -6,7 +6,12 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
-from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -19,7 +24,7 @@ from .entity import RutOSEntity
 class RutOSSensorEntityDescription(SensorEntityDescription):
     """Describe a RutOS sensor entity."""
 
-    value_fn: Callable[[dict[str, Any]], str | int | None]
+    value_fn: Callable[[dict[str, Any]], str | int | float | None]
 
 
 INTERFACE_SENSORS: tuple[RutOSSensorEntityDescription, ...] = (
@@ -47,6 +52,36 @@ INTERFACE_SENSORS: tuple[RutOSSensorEntityDescription, ...] = (
 )
 
 
+DATA_LIMIT_SENSORS: tuple[RutOSSensorEntityDescription, ...] = (
+    RutOSSensorEntityDescription(
+        key="data_used",
+        translation_key="data_used",
+        native_unit_of_measurement="B",
+        device_class=SensorDeviceClass.DATA_SIZE,
+        state_class=SensorStateClass.TOTAL,
+        value_fn=lambda d: d.get("data_used"),
+    ),
+    RutOSSensorEntityDescription(
+        key="data_limit",
+        translation_key="data_limit",
+        native_unit_of_measurement="B",
+        device_class=SensorDeviceClass.DATA_SIZE,
+        value_fn=lambda d: d.get("data_limit"),
+    ),
+    RutOSSensorEntityDescription(
+        key="data_usage_percent",
+        translation_key="data_usage_percent",
+        native_unit_of_measurement="%",
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda d: (
+            round(d["data_used"] / d["data_limit"] * 100, 1)
+            if d.get("data_limit")
+            else None
+        ),
+    ),
+)
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -54,11 +89,21 @@ async def async_setup_entry(
 ) -> None:
     """Set up RutOS sensors based on a config entry."""
     coordinator: RutOSDataUpdateCoordinator = entry.runtime_data
-    async_add_entities([
+    entities: list[SensorEntity] = [
         RutOSSensorEntity(coordinator, description, iface["name"])
         for iface in coordinator.data.wan_interfaces
         for description in INTERFACE_SENSORS
-    ] + [RutOSActiveWANSensor(coordinator)])
+    ]
+    entities.append(RutOSActiveWANSensor(coordinator))
+    for limit in coordinator.data.data_limit:
+        limit_id = limit.get("id", "")
+        if not limit.get("enabled"):
+            continue
+        entities.extend(
+            RutOSDataLimitSensor(coordinator, desc, limit_id)
+            for desc in DATA_LIMIT_SENSORS
+        )
+    async_add_entities(entities)
 
 
 class RutOSSensorEntity(RutOSEntity, SensorEntity):
@@ -82,12 +127,48 @@ class RutOSSensorEntity(RutOSEntity, SensorEntity):
         self._attr_translation_placeholders = {"interface": interface_name}
 
     @property
-    def native_value(self) -> str | int | None:
+    def native_value(self) -> str | int | float | None:
         """Return the sensor value."""
         iface = self._find_interface(self._interface_name)
         if iface is None:
             return None
         return self.entity_description.value_fn(iface)
+
+
+class RutOSDataLimitSensor(RutOSEntity, SensorEntity):
+    """Representation of a RutOS data limit/usage sensor."""
+
+    entity_description: RutOSSensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: RutOSDataUpdateCoordinator,
+        description: RutOSSensorEntityDescription,
+        limit_id: str,
+    ) -> None:
+        """Initialize the data limit sensor."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._limit_id = limit_id
+        self._attr_unique_id = (
+            f"{coordinator.data.device_info.get('serial', '')}_{limit_id}_{description.key}"
+        )
+        self._attr_translation_placeholders = {"limit": limit_id}
+
+    def _find_limit(self) -> dict[str, Any] | None:
+        """Find data limit entry by id."""
+        for limit in self.coordinator.data.data_limit:
+            if limit.get("id") == self._limit_id:
+                return limit
+        return None
+
+    @property
+    def native_value(self) -> str | int | float | None:
+        """Return the sensor value."""
+        limit = self._find_limit()
+        if limit is None:
+            return None
+        return self.entity_description.value_fn(limit)
 
 
 class RutOSActiveWANSensor(RutOSEntity, SensorEntity):

--- a/custom_components/rutos/translations/en.json
+++ b/custom_components/rutos/translations/en.json
@@ -36,6 +36,20 @@
       },
       "active_wan": {
         "name": "Active WAN interface"
+      },
+      "data_used": {
+        "name": "{limit} data used"
+      },
+      "data_limit": {
+        "name": "{limit} data limit"
+      },
+      "data_usage_percent": {
+        "name": "{limit} data usage"
+      }
+    },
+    "button": {
+      "clear_data_usage": {
+        "name": "Clear data usage"
       }
     },
     "binary_sensor": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,12 +63,30 @@ def mock_wan_interfaces() -> list[dict]:
 
 
 @pytest.fixture
-def mock_rutos_data(mock_device_info, mock_wan_interfaces) -> RutOSData:
+def mock_data_limit() -> list[dict]:
+    """Return mock data limit status."""
+    return [
+        {
+            "id": "limit1",
+            "interface": "mob1s1a1",
+            "enabled": True,
+            "data_limit": 5_000_000_000,
+            "data_used": 2_500_000_000,
+            "data_warning_enabled": True,
+            "data_warning_limit": 4_000_000_000,
+            "due_reset_time": 1735689600,
+        },
+    ]
+
+
+@pytest.fixture
+def mock_rutos_data(mock_device_info, mock_wan_interfaces, mock_data_limit) -> RutOSData:
     """Return a populated RutOSData instance."""
     return RutOSData(
         device_info=mock_device_info,
         wan_interfaces=mock_wan_interfaces,
         internet_available=True,
+        data_limit=mock_data_limit,
     )
 
 
@@ -80,6 +98,19 @@ def mock_api(mock_device_info, mock_wan_interfaces) -> AsyncMock:
     api.get_device_info.return_value = mock_device_info
     api.get_wan_interfaces.return_value = mock_wan_interfaces
     api.get_internet_status.return_value = True
+    api.get_data_limit.return_value = [
+        {
+            "id": "limit1",
+            "interface": "mob1s1a1",
+            "enabled": True,
+            "data_limit": 5_000_000_000,
+            "data_used": 2_500_000_000,
+            "data_warning_enabled": True,
+            "data_warning_limit": 4_000_000_000,
+            "due_reset_time": 1735689600,
+        },
+    ]
+    api.clear_data_usage.return_value = None
     api.set_interface_enabled.return_value = None
     api.set_failover_order.return_value = None
     return api

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -662,3 +662,81 @@ class TestGetInternetStatusVariants:
             )
 
             assert await api_client.get_internet_status() is True
+
+
+class TestGetDataLimit:
+    """Tests for get_data_limit."""
+
+    async def test_get_data_limit_success(self, api_client):
+        """Test parsing of data limit status response."""
+        data = [
+            {
+                "id": "limit1",
+                "interface": "mob1s1a1",
+                "enabled": True,
+                "data_limit": 5000000000,
+                "data_used": 2500000000,
+                "data_warning_enabled": True,
+                "data_warning_limit": 4000000000,
+                "due_reset_time": 1735689600,
+            },
+        ]
+        with aioresponses() as m:
+            m.post(_url("/login"), payload=_login_success())
+            m.get(_url("/data_limit/status"), payload=_success(data))
+
+            result = await api_client.get_data_limit()
+
+            assert len(result) == 1
+            assert result[0]["id"] == "limit1"
+            assert result[0]["data_used"] == 2500000000
+            assert result[0]["data_limit"] == 5000000000
+
+    async def test_get_data_limit_empty(self, api_client):
+        """Test returns empty list when no limits configured."""
+        with aioresponses() as m:
+            m.post(_url("/login"), payload=_login_success())
+            m.get(_url("/data_limit/status"), payload=_success([]))
+
+            result = await api_client.get_data_limit()
+            assert result == []
+
+    async def test_get_data_limit_api_error(self, api_client):
+        """Test returns empty list on API error."""
+        with aioresponses() as m:
+            m.post(_url("/login"), payload=_login_success())
+            m.get(
+                _url("/data_limit/status"),
+                payload=_error("Service unavailable"),
+            )
+
+            result = await api_client.get_data_limit()
+            assert result == []
+
+    async def test_get_data_limit_non_list(self, api_client):
+        """Test returns empty list for non-list response."""
+        with aioresponses() as m:
+            m.post(_url("/login"), payload=_login_success())
+            m.get(_url("/data_limit/status"), payload=_success({"unexpected": True}))
+
+            result = await api_client.get_data_limit()
+            assert result == []
+
+
+class TestClearDataUsage:
+    """Tests for clear_data_usage."""
+
+    async def test_clear_data_usage(self, api_client):
+        """Test clear data usage sends POST."""
+        with aioresponses() as m:
+            m.post(_url("/login"), payload=_login_success())
+            m.post(_url("/data_limit/actions/clear"), payload=_success())
+
+            await api_client.clear_data_usage()
+
+            # Verify the POST was sent
+            post_count = sum(
+                1 for key in m.requests
+                if key[0] == "POST" and "clear" in str(key[1])
+            )
+            assert post_count == 1

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -1,0 +1,31 @@
+"""Tests for the RutOS button platform."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+from custom_components.rutos.button import RutOSClearDataUsageButton
+from custom_components.rutos.coordinator import RutOSDataUpdateCoordinator
+
+
+class TestRutOSClearDataUsageButton:
+    """Tests for the clear data usage button."""
+
+    def test_unique_id(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Test unique_id is {serial}_clear_data_usage."""
+        button = RutOSClearDataUsageButton(mock_coordinator)
+        assert button.unique_id == "1234567890_clear_data_usage"
+
+    async def test_press_calls_api(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Test pressing the button calls clear_data_usage + refresh."""
+        mock_coordinator.async_request_refresh = AsyncMock()
+        button = RutOSClearDataUsageButton(mock_coordinator)
+
+        await button.async_press()
+
+        mock_coordinator.api.clear_data_usage.assert_awaited_once()
+        mock_coordinator.async_request_refresh.assert_awaited_once()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -64,8 +64,11 @@ async def test_async_update_data_returns_rutos_data(
     assert isinstance(result, RutOSData)
     assert result.wan_interfaces == mock_wan_interfaces
     assert result.internet_available is True
+    assert len(result.data_limit) == 1
+    assert result.data_limit[0]["id"] == "limit1"
     mock_api.get_wan_interfaces.assert_awaited_once()
     mock_api.get_internet_status.assert_awaited_once()
+    mock_api.get_data_limit.assert_awaited_once()
 
 
 async def test_async_update_data_auth_error_raises_update_failed(
@@ -125,3 +128,4 @@ async def test_async_update_data_initializes_data_when_none(
 
     assert isinstance(result, RutOSData)
     assert result.wan_interfaces == mock_wan_interfaces
+    assert len(result.data_limit) == 1

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -70,6 +70,7 @@ def mock_api_instance():
     api.get_device_info.return_value = MOCK_DEVICE_INFO
     api.get_wan_interfaces.return_value = MOCK_WAN_INTERFACES
     api.get_internet_status.return_value = True
+    api.get_data_limit.return_value = []
     api.set_failover_order.return_value = None
     return api
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -11,8 +11,10 @@ from homeassistant.core import HomeAssistant
 from custom_components.rutos.const import DOMAIN
 from custom_components.rutos.coordinator import RutOSData, RutOSDataUpdateCoordinator
 from custom_components.rutos.sensor import (
+    DATA_LIMIT_SENSORS,
     INTERFACE_SENSORS,
     RutOSActiveWANSensor,
+    RutOSDataLimitSensor,
     RutOSSensorEntity,
 )
 
@@ -124,3 +126,56 @@ class TestRutOSActiveWANSensor:
         """Test unique_id is {serial}_active_wan."""
         sensor = RutOSActiveWANSensor(mock_coordinator)
         assert sensor.unique_id == "1234567890_active_wan"
+
+
+class TestRutOSDataLimitSensor:
+    """Tests for data limit sensor entities."""
+
+    def test_data_used_value(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Test data used sensor returns bytes used."""
+        desc = DATA_LIMIT_SENSORS[0]  # data_used
+        sensor = RutOSDataLimitSensor(mock_coordinator, desc, "limit1")
+        assert sensor.native_value == 2_500_000_000
+
+    def test_data_limit_value(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Test data limit sensor returns limit in bytes."""
+        desc = DATA_LIMIT_SENSORS[1]  # data_limit
+        sensor = RutOSDataLimitSensor(mock_coordinator, desc, "limit1")
+        assert sensor.native_value == 5_000_000_000
+
+    def test_data_usage_percent(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Test data usage percent is calculated correctly."""
+        desc = DATA_LIMIT_SENSORS[2]  # data_usage_percent
+        sensor = RutOSDataLimitSensor(mock_coordinator, desc, "limit1")
+        assert sensor.native_value == 50.0
+
+    def test_data_usage_percent_zero_limit(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Test data usage percent returns None when limit is 0."""
+        mock_coordinator.data.data_limit[0]["data_limit"] = 0
+        desc = DATA_LIMIT_SENSORS[2]
+        sensor = RutOSDataLimitSensor(mock_coordinator, desc, "limit1")
+        assert sensor.native_value is None
+
+    def test_missing_limit_returns_none(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Test returns None when limit not found."""
+        desc = DATA_LIMIT_SENSORS[0]
+        sensor = RutOSDataLimitSensor(mock_coordinator, desc, "nonexistent")
+        assert sensor.native_value is None
+
+    def test_unique_id_format(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Test unique_id follows {serial}_{limit}_{key} pattern."""
+        desc = DATA_LIMIT_SENSORS[0]
+        sensor = RutOSDataLimitSensor(mock_coordinator, desc, "limit1")
+        assert sensor.unique_id == "1234567890_limit1_data_used"


### PR DESCRIPTION
## Summary
- Adds per-limit sensors for data used (bytes), data limit (bytes), and usage percentage
- Only creates entities for enabled data limits from `GET /data_limit/status`
- Adds a button entity to clear/reset data usage counters via `POST /data_limit/actions/clear`
- Adds the `button` platform to the integration

## Test plan
- [x] API tests: get_data_limit success/empty/error/non-list, clear_data_usage
- [x] Sensor tests: data used, data limit, usage percent, zero limit edge case, missing limit
- [x] Button tests: unique ID, press calls API + refresh
- [x] Coordinator tests: data limit included in parallel fetch
- [x] All 96 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)