### PR TITLE
Add modem reboot button

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ failover control.
 - **WAN Interface Switches** — Enable/disable individual WAN interfaces
 - **Failover Ordering** — Service call to reorder WAN interface failover
   priority
+- **Modem Reboot** — Button to reboot individual modems without rebooting the
+  entire device
 
 ## Installation
 

--- a/custom_components/rutos/__init__.py
+++ b/custom_components/rutos/__init__.py
@@ -28,6 +28,7 @@ PLATFORMS: list[Platform] = [
     Platform.SENSOR,
     Platform.BINARY_SENSOR,
     Platform.SWITCH,
+    Platform.BUTTON,
 ]
 
 type RutOSConfigEntry = ConfigEntry[RutOSDataUpdateCoordinator]

--- a/custom_components/rutos/api.py
+++ b/custom_components/rutos/api.py
@@ -244,6 +244,26 @@ class RutOSAPI:
             {"data": {"enabled": "1" if enabled else "0"}},
         )
 
+    async def reboot_modem(self, modem_id: str) -> None:
+        """Reboot a specific modem."""
+        await self.post(f"/modems/{modem_id}/actions/reboot")
+
+    async def get_modems(self) -> list[dict[str, Any]]:
+        """Fetch list of available modems."""
+        try:
+            data = await self.get("/modems/signal/status")
+        except RutOSAPIError:
+            return []
+
+        if not isinstance(data, list):
+            return []
+
+        return [
+            {"id": modem.get("id", "")}
+            for modem in data
+            if isinstance(modem, dict) and modem.get("id")
+        ]
+
     async def set_failover_order(self, interfaces: list[str]) -> None:
         """Set the failover order by updating interface metrics."""
         for idx, iface_id in enumerate(interfaces):

--- a/custom_components/rutos/button.py
+++ b/custom_components/rutos/button.py
@@ -1,0 +1,48 @@
+"""Button platform for the RutOS integration."""
+
+from __future__ import annotations
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .coordinator import RutOSDataUpdateCoordinator
+from .entity import RutOSEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up RutOS buttons based on a config entry."""
+    coordinator: RutOSDataUpdateCoordinator = entry.runtime_data
+    async_add_entities([
+        RutOSModemRebootButton(coordinator, modem["id"])
+        for modem in coordinator.data.modems
+    ])
+
+
+class RutOSModemRebootButton(RutOSEntity, ButtonEntity):
+    """Button to reboot a specific modem."""
+
+    _attr_translation_key = "modem_reboot"
+
+    def __init__(
+        self,
+        coordinator: RutOSDataUpdateCoordinator,
+        modem_id: str,
+    ) -> None:
+        """Initialize the button."""
+        super().__init__(coordinator)
+        self._modem_id = modem_id
+        self._attr_unique_id = (
+            f"{coordinator.data.device_info.get('serial', '')}_{modem_id}_reboot"
+        )
+        self._attr_translation_placeholders = {"modem": modem_id}
+
+    async def async_press(self) -> None:
+        """Handle the button press."""
+        await self.coordinator.api.reboot_modem(self._modem_id)
+        await self.coordinator.async_request_refresh()

--- a/custom_components/rutos/coordinator.py
+++ b/custom_components/rutos/coordinator.py
@@ -24,6 +24,7 @@ class RutOSData:
     device_info: dict[str, Any] = field(default_factory=dict)
     wan_interfaces: list[dict[str, Any]] = field(default_factory=list)
     internet_available: bool = False
+    modems: list[dict[str, Any]] = field(default_factory=list)
 
 
 class RutOSDataUpdateCoordinator(DataUpdateCoordinator[RutOSData]):
@@ -58,9 +59,10 @@ class RutOSDataUpdateCoordinator(DataUpdateCoordinator[RutOSData]):
             self.data = RutOSData()
 
         try:
-            wan_interfaces, internet_available = await asyncio.gather(
+            wan_interfaces, internet_available, modems = await asyncio.gather(
                 self.api.get_wan_interfaces(),
                 self.api.get_internet_status(),
+                self.api.get_modems(),
             )
         except RutOSAuthError as err:
             raise UpdateFailed(f"Authentication failed: {err}") from err
@@ -69,4 +71,5 @@ class RutOSDataUpdateCoordinator(DataUpdateCoordinator[RutOSData]):
 
         self.data.wan_interfaces = wan_interfaces
         self.data.internet_available = internet_available
+        self.data.modems = modems
         return self.data

--- a/custom_components/rutos/translations/en.json
+++ b/custom_components/rutos/translations/en.json
@@ -38,6 +38,11 @@
         "name": "Active WAN interface"
       }
     },
+    "button": {
+      "modem_reboot": {
+        "name": "Reboot {modem}"
+      }
+    },
     "binary_sensor": {
       "internet_connectivity": {
         "name": "Internet connectivity"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,12 +63,19 @@ def mock_wan_interfaces() -> list[dict]:
 
 
 @pytest.fixture
-def mock_rutos_data(mock_device_info, mock_wan_interfaces) -> RutOSData:
+def mock_modems() -> list[dict]:
+    """Return mock modem list."""
+    return [{"id": "modem1"}]
+
+
+@pytest.fixture
+def mock_rutos_data(mock_device_info, mock_wan_interfaces, mock_modems) -> RutOSData:
     """Return a populated RutOSData instance."""
     return RutOSData(
         device_info=mock_device_info,
         wan_interfaces=mock_wan_interfaces,
         internet_available=True,
+        modems=mock_modems,
     )
 
 
@@ -80,6 +87,8 @@ def mock_api(mock_device_info, mock_wan_interfaces) -> AsyncMock:
     api.get_device_info.return_value = mock_device_info
     api.get_wan_interfaces.return_value = mock_wan_interfaces
     api.get_internet_status.return_value = True
+    api.get_modems.return_value = [{"id": "modem1"}]
+    api.reboot_modem.return_value = None
     api.set_interface_enabled.return_value = None
     api.set_failover_order.return_value = None
     return api

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -662,3 +662,62 @@ class TestGetInternetStatusVariants:
             )
 
             assert await api_client.get_internet_status() is True
+
+
+class TestRebootModem:
+    """Tests for reboot_modem."""
+
+    async def test_reboot_modem(self, api_client):
+        """Test modem reboot sends POST to correct endpoint."""
+        with aioresponses() as m:
+            m.post(_url("/login"), payload=_login_success())
+            m.post(_url("/modems/modem1/actions/reboot"), payload=_success())
+
+            await api_client.reboot_modem("modem1")
+
+            post_count = sum(
+                1 for key in m.requests
+                if key[0] == "POST" and "modem1" in str(key[1])
+            )
+            assert post_count == 1
+
+
+class TestGetModems:
+    """Tests for get_modems."""
+
+    async def test_get_modems_success(self, api_client):
+        """Test parsing modem list from signal status."""
+        signal_data = [
+            {"id": "modem1", "rssi": -65},
+            {"id": "modem2", "rssi": -70},
+        ]
+        with aioresponses() as m:
+            m.post(_url("/login"), payload=_login_success())
+            m.get(_url("/modems/signal/status"), payload=_success(signal_data))
+
+            result = await api_client.get_modems()
+
+            assert len(result) == 2
+            assert result[0]["id"] == "modem1"
+            assert result[1]["id"] == "modem2"
+
+    async def test_get_modems_empty(self, api_client):
+        """Test returns empty list when no modems."""
+        with aioresponses() as m:
+            m.post(_url("/login"), payload=_login_success())
+            m.get(_url("/modems/signal/status"), payload=_success([]))
+
+            result = await api_client.get_modems()
+            assert result == []
+
+    async def test_get_modems_api_error(self, api_client):
+        """Test returns empty list on API error."""
+        with aioresponses() as m:
+            m.post(_url("/login"), payload=_login_success())
+            m.get(
+                _url("/modems/signal/status"),
+                payload=_error("Service unavailable"),
+            )
+
+            result = await api_client.get_modems()
+            assert result == []

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -1,0 +1,52 @@
+"""Tests for the RutOS button platform."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+from custom_components.rutos.api import RutOSAPIError
+from custom_components.rutos.button import RutOSModemRebootButton
+from custom_components.rutos.coordinator import RutOSDataUpdateCoordinator
+
+
+class TestRutOSModemRebootButton:
+    """Tests for the modem reboot button."""
+
+    def test_unique_id(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Test unique_id is {serial}_{modem}_reboot."""
+        button = RutOSModemRebootButton(mock_coordinator, "modem1")
+        assert button.unique_id == "1234567890_modem1_reboot"
+
+    async def test_press_calls_api(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Test pressing the button calls reboot_modem + refresh."""
+        mock_coordinator.async_request_refresh = AsyncMock()
+        button = RutOSModemRebootButton(mock_coordinator, "modem1")
+
+        await button.async_press()
+
+        mock_coordinator.api.reboot_modem.assert_awaited_once_with("modem1")
+        mock_coordinator.async_request_refresh.assert_awaited_once()
+
+    async def test_api_error_propagates(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Test API errors are not swallowed."""
+        import pytest
+
+        mock_coordinator.api.reboot_modem.side_effect = RutOSAPIError("fail")
+        mock_coordinator.async_request_refresh = AsyncMock()
+        button = RutOSModemRebootButton(mock_coordinator, "modem1")
+
+        with pytest.raises(RutOSAPIError):
+            await button.async_press()
+
+    def test_translation_placeholders(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Test translation placeholders include modem id."""
+        button = RutOSModemRebootButton(mock_coordinator, "modem1")
+        assert button.translation_placeholders == {"modem": "modem1"}

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -64,8 +64,11 @@ async def test_async_update_data_returns_rutos_data(
     assert isinstance(result, RutOSData)
     assert result.wan_interfaces == mock_wan_interfaces
     assert result.internet_available is True
+    assert len(result.modems) == 1
+    assert result.modems[0]["id"] == "modem1"
     mock_api.get_wan_interfaces.assert_awaited_once()
     mock_api.get_internet_status.assert_awaited_once()
+    mock_api.get_modems.assert_awaited_once()
 
 
 async def test_async_update_data_auth_error_raises_update_failed(
@@ -125,3 +128,4 @@ async def test_async_update_data_initializes_data_when_none(
 
     assert isinstance(result, RutOSData)
     assert result.wan_interfaces == mock_wan_interfaces
+    assert len(result.modems) == 1

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -70,6 +70,7 @@ def mock_api_instance():
     api.get_device_info.return_value = MOCK_DEVICE_INFO
     api.get_wan_interfaces.return_value = MOCK_WAN_INTERFACES
     api.get_internet_status.return_value = True
+    api.get_modems.return_value = []
     api.set_failover_order.return_value = None
     return api
 


### PR DESCRIPTION
## Summary
- Adds a button entity per detected modem to trigger a reboot via `POST /modems/{id}/actions/reboot`
- Modem discovery reuses the signal status endpoint (`GET /modems/signal/status`)
- Adds the `button` platform to the integration
- Refreshes coordinator data after reboot to reflect updated state

## Test plan
- [x] API tests: reboot_modem sends POST, get_modems success/empty/error
- [x] Button tests: unique ID, press calls API + refresh, error propagation, translation placeholders
- [x] Coordinator tests: modems list included in parallel fetch
- [x] All 91 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)