### PR TITLE
Add GPS position tracking with device tracker and sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ failover control.
 - **WAN Interface Switches** — Enable/disable individual WAN interfaces
 - **Failover Ordering** — Service call to reorder WAN interface failover
   priority
+- **GPS Tracking** — Device tracker with real-time location on the HA map, plus
+  sensors for speed, altitude, heading, satellites, and fix status
 
 ## Installation
 

--- a/custom_components/rutos/__init__.py
+++ b/custom_components/rutos/__init__.py
@@ -28,6 +28,7 @@ PLATFORMS: list[Platform] = [
     Platform.SENSOR,
     Platform.BINARY_SENSOR,
     Platform.SWITCH,
+    Platform.DEVICE_TRACKER,
 ]
 
 type RutOSConfigEntry = ConfigEntry[RutOSDataUpdateCoordinator]

--- a/custom_components/rutos/api.py
+++ b/custom_components/rutos/api.py
@@ -252,3 +252,28 @@ class RutOSAPI:
                 f"/interfaces/config/{iface_id}",
                 {"data": {"metric": str(metric)}},
             )
+
+    async def get_gps_position(self) -> dict[str, Any] | None:
+        """Fetch GPS position data (lat, lon, speed, altitude, etc.)."""
+        try:
+            data = await self.get("/gps/position/status")
+        except RutOSAPIError:
+            return None
+
+        if not isinstance(data, dict):
+            return None
+
+        # Only return data if we have a valid fix
+        if not data.get("latitude") and not data.get("longitude"):
+            return None
+
+        return {
+            "latitude": data.get("latitude"),
+            "longitude": data.get("longitude"),
+            "accuracy": data.get("accuracy"),
+            "altitude": data.get("altitude"),
+            "speed": data.get("speed"),
+            "angle": data.get("angle"),
+            "satellites": data.get("satellites"),
+            "fix_status": data.get("fix_status"),
+        }

--- a/custom_components/rutos/coordinator.py
+++ b/custom_components/rutos/coordinator.py
@@ -24,6 +24,7 @@ class RutOSData:
     device_info: dict[str, Any] = field(default_factory=dict)
     wan_interfaces: list[dict[str, Any]] = field(default_factory=list)
     internet_available: bool = False
+    gps_position: dict[str, Any] | None = None
 
 
 class RutOSDataUpdateCoordinator(DataUpdateCoordinator[RutOSData]):
@@ -58,9 +59,12 @@ class RutOSDataUpdateCoordinator(DataUpdateCoordinator[RutOSData]):
             self.data = RutOSData()
 
         try:
-            wan_interfaces, internet_available = await asyncio.gather(
-                self.api.get_wan_interfaces(),
-                self.api.get_internet_status(),
+            wan_interfaces, internet_available, gps_position = (
+                await asyncio.gather(
+                    self.api.get_wan_interfaces(),
+                    self.api.get_internet_status(),
+                    self.api.get_gps_position(),
+                )
             )
         except RutOSAuthError as err:
             raise UpdateFailed(f"Authentication failed: {err}") from err
@@ -69,4 +73,5 @@ class RutOSDataUpdateCoordinator(DataUpdateCoordinator[RutOSData]):
 
         self.data.wan_interfaces = wan_interfaces
         self.data.internet_available = internet_available
+        self.data.gps_position = gps_position
         return self.data

--- a/custom_components/rutos/device_tracker.py
+++ b/custom_components/rutos/device_tracker.py
@@ -1,0 +1,64 @@
+"""Device tracker platform for the RutOS integration."""
+
+from __future__ import annotations
+
+from homeassistant.components.device_tracker.const import SourceType
+from homeassistant.components.device_tracker.config_entry import TrackerEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .coordinator import RutOSDataUpdateCoordinator
+from .entity import RutOSEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up RutOS device tracker based on a config entry."""
+    coordinator: RutOSDataUpdateCoordinator = entry.runtime_data
+    async_add_entities([RutOSDeviceTracker(coordinator)])
+
+
+class RutOSDeviceTracker(RutOSEntity, TrackerEntity):
+    """Device tracker using GPS position from the RutOS router."""
+
+    _attr_translation_key = "gps_location"
+
+    def __init__(self, coordinator: RutOSDataUpdateCoordinator) -> None:
+        """Initialize the device tracker."""
+        super().__init__(coordinator)
+        self._attr_unique_id = (
+            f"{coordinator.data.device_info.get('serial', '')}_gps_location"
+        )
+
+    @property
+    def source_type(self) -> SourceType:
+        """Return the source type."""
+        return SourceType.GPS
+
+    @property
+    def latitude(self) -> float | None:
+        """Return latitude value of the device."""
+        gps = self.coordinator.data.gps_position
+        if gps is None:
+            return None
+        return gps.get("latitude")
+
+    @property
+    def longitude(self) -> float | None:
+        """Return longitude value of the device."""
+        gps = self.coordinator.data.gps_position
+        if gps is None:
+            return None
+        return gps.get("longitude")
+
+    @property
+    def location_accuracy(self) -> int:
+        """Return the location accuracy of the device."""
+        gps = self.coordinator.data.gps_position
+        if gps is None:
+            return 0
+        return gps.get("accuracy", 0)

--- a/custom_components/rutos/sensor.py
+++ b/custom_components/rutos/sensor.py
@@ -6,7 +6,12 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
-from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -19,7 +24,7 @@ from .entity import RutOSEntity
 class RutOSSensorEntityDescription(SensorEntityDescription):
     """Describe a RutOS sensor entity."""
 
-    value_fn: Callable[[dict[str, Any]], str | int | None]
+    value_fn: Callable[[dict[str, Any]], str | int | float | None]
 
 
 INTERFACE_SENSORS: tuple[RutOSSensorEntityDescription, ...] = (
@@ -47,6 +52,43 @@ INTERFACE_SENSORS: tuple[RutOSSensorEntityDescription, ...] = (
 )
 
 
+GPS_SENSORS: tuple[RutOSSensorEntityDescription, ...] = (
+    RutOSSensorEntityDescription(
+        key="gps_speed",
+        translation_key="gps_speed",
+        native_unit_of_measurement="km/h",
+        device_class=SensorDeviceClass.SPEED,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda gps: gps.get("speed"),
+    ),
+    RutOSSensorEntityDescription(
+        key="gps_altitude",
+        translation_key="gps_altitude",
+        native_unit_of_measurement="m",
+        device_class=SensorDeviceClass.DISTANCE,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda gps: gps.get("altitude"),
+    ),
+    RutOSSensorEntityDescription(
+        key="gps_satellites",
+        translation_key="gps_satellites",
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda gps: gps.get("satellites"),
+    ),
+    RutOSSensorEntityDescription(
+        key="gps_heading",
+        translation_key="gps_heading",
+        native_unit_of_measurement="°",
+        value_fn=lambda gps: gps.get("angle"),
+    ),
+    RutOSSensorEntityDescription(
+        key="gps_fix_status",
+        translation_key="gps_fix_status",
+        value_fn=lambda gps: gps.get("fix_status"),
+    ),
+)
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -54,11 +96,16 @@ async def async_setup_entry(
 ) -> None:
     """Set up RutOS sensors based on a config entry."""
     coordinator: RutOSDataUpdateCoordinator = entry.runtime_data
-    async_add_entities([
+    entities: list[SensorEntity] = [
         RutOSSensorEntity(coordinator, description, iface["name"])
         for iface in coordinator.data.wan_interfaces
         for description in INTERFACE_SENSORS
-    ] + [RutOSActiveWANSensor(coordinator)])
+    ]
+    entities.append(RutOSActiveWANSensor(coordinator))
+    entities.extend(
+        RutOSGPSSensorEntity(coordinator, desc) for desc in GPS_SENSORS
+    )
+    async_add_entities(entities)
 
 
 class RutOSSensorEntity(RutOSEntity, SensorEntity):
@@ -82,12 +129,38 @@ class RutOSSensorEntity(RutOSEntity, SensorEntity):
         self._attr_translation_placeholders = {"interface": interface_name}
 
     @property
-    def native_value(self) -> str | int | None:
+    def native_value(self) -> str | int | float | None:
         """Return the sensor value."""
         iface = self._find_interface(self._interface_name)
         if iface is None:
             return None
         return self.entity_description.value_fn(iface)
+
+
+class RutOSGPSSensorEntity(RutOSEntity, SensorEntity):
+    """Representation of a RutOS GPS sensor."""
+
+    entity_description: RutOSSensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: RutOSDataUpdateCoordinator,
+        description: RutOSSensorEntityDescription,
+    ) -> None:
+        """Initialize the GPS sensor."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = (
+            f"{coordinator.data.device_info.get('serial', '')}_{description.key}"
+        )
+
+    @property
+    def native_value(self) -> str | int | float | None:
+        """Return the sensor value."""
+        gps = self.coordinator.data.gps_position
+        if gps is None:
+            return None
+        return self.entity_description.value_fn(gps)
 
 
 class RutOSActiveWANSensor(RutOSEntity, SensorEntity):

--- a/custom_components/rutos/translations/en.json
+++ b/custom_components/rutos/translations/en.json
@@ -36,6 +36,26 @@
       },
       "active_wan": {
         "name": "Active WAN interface"
+      },
+      "gps_speed": {
+        "name": "GPS speed"
+      },
+      "gps_altitude": {
+        "name": "GPS altitude"
+      },
+      "gps_satellites": {
+        "name": "GPS satellites"
+      },
+      "gps_heading": {
+        "name": "GPS heading"
+      },
+      "gps_fix_status": {
+        "name": "GPS fix status"
+      }
+    },
+    "device_tracker": {
+      "gps_location": {
+        "name": "GPS location"
       }
     },
     "binary_sensor": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,12 +63,28 @@ def mock_wan_interfaces() -> list[dict]:
 
 
 @pytest.fixture
-def mock_rutos_data(mock_device_info, mock_wan_interfaces) -> RutOSData:
+def mock_gps_position() -> dict:
+    """Return mock GPS position data."""
+    return {
+        "latitude": 37.7749,
+        "longitude": -122.4194,
+        "accuracy": 5,
+        "altitude": 15.2,
+        "speed": 65.3,
+        "angle": 180,
+        "satellites": 12,
+        "fix_status": "3D",
+    }
+
+
+@pytest.fixture
+def mock_rutos_data(mock_device_info, mock_wan_interfaces, mock_gps_position) -> RutOSData:
     """Return a populated RutOSData instance."""
     return RutOSData(
         device_info=mock_device_info,
         wan_interfaces=mock_wan_interfaces,
         internet_available=True,
+        gps_position=mock_gps_position,
     )
 
 
@@ -80,6 +96,16 @@ def mock_api(mock_device_info, mock_wan_interfaces) -> AsyncMock:
     api.get_device_info.return_value = mock_device_info
     api.get_wan_interfaces.return_value = mock_wan_interfaces
     api.get_internet_status.return_value = True
+    api.get_gps_position.return_value = {
+        "latitude": 37.7749,
+        "longitude": -122.4194,
+        "accuracy": 5,
+        "altitude": 15.2,
+        "speed": 65.3,
+        "angle": 180,
+        "satellites": 12,
+        "fix_status": "3D",
+    }
     api.set_interface_enabled.return_value = None
     api.set_failover_order.return_value = None
     return api

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -662,3 +662,63 @@ class TestGetInternetStatusVariants:
             )
 
             assert await api_client.get_internet_status() is True
+
+
+class TestGetGPSPosition:
+    """Tests for get_gps_position."""
+
+    async def test_get_gps_position_success(self, api_client):
+        """Test parsing of GPS position response."""
+        gps_data = {
+            "latitude": 37.7749,
+            "longitude": -122.4194,
+            "accuracy": 5,
+            "altitude": 15.2,
+            "speed": 65.3,
+            "angle": 180,
+            "satellites": 12,
+            "fix_status": "3D",
+        }
+        with aioresponses() as m:
+            m.post(_url("/login"), payload=_login_success())
+            m.get(_url("/gps/position/status"), payload=_success(gps_data))
+
+            result = await api_client.get_gps_position()
+
+            assert result["latitude"] == 37.7749
+            assert result["longitude"] == -122.4194
+            assert result["speed"] == 65.3
+            assert result["satellites"] == 12
+
+    async def test_get_gps_position_no_fix(self, api_client):
+        """Test returns None when no GPS fix (no lat/lon)."""
+        with aioresponses() as m:
+            m.post(_url("/login"), payload=_login_success())
+            m.get(
+                _url("/gps/position/status"),
+                payload=_success({"fix_status": "no_fix"}),
+            )
+
+            result = await api_client.get_gps_position()
+            assert result is None
+
+    async def test_get_gps_position_api_error(self, api_client):
+        """Test returns None on API error (GPS not available)."""
+        with aioresponses() as m:
+            m.post(_url("/login"), payload=_login_success())
+            m.get(
+                _url("/gps/position/status"),
+                payload=_error("Service unavailable"),
+            )
+
+            result = await api_client.get_gps_position()
+            assert result is None
+
+    async def test_get_gps_position_non_dict(self, api_client):
+        """Test returns None for non-dict response."""
+        with aioresponses() as m:
+            m.post(_url("/login"), payload=_login_success())
+            m.get(_url("/gps/position/status"), payload=_success([]))
+
+            result = await api_client.get_gps_position()
+            assert result is None

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -64,8 +64,11 @@ async def test_async_update_data_returns_rutos_data(
     assert isinstance(result, RutOSData)
     assert result.wan_interfaces == mock_wan_interfaces
     assert result.internet_available is True
+    assert result.gps_position is not None
+    assert result.gps_position["latitude"] == 37.7749
     mock_api.get_wan_interfaces.assert_awaited_once()
     mock_api.get_internet_status.assert_awaited_once()
+    mock_api.get_gps_position.assert_awaited_once()
 
 
 async def test_async_update_data_auth_error_raises_update_failed(
@@ -125,3 +128,4 @@ async def test_async_update_data_initializes_data_when_none(
 
     assert isinstance(result, RutOSData)
     assert result.wan_interfaces == mock_wan_interfaces
+    assert result.gps_position is not None

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -1,0 +1,57 @@
+"""Tests for the RutOS device tracker platform."""
+
+from __future__ import annotations
+
+from homeassistant.components.device_tracker.const import SourceType
+
+from custom_components.rutos.coordinator import RutOSDataUpdateCoordinator
+from custom_components.rutos.device_tracker import RutOSDeviceTracker
+
+
+class TestRutOSDeviceTracker:
+    """Tests for the GPS device tracker."""
+
+    def test_latitude(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Test latitude from GPS data."""
+        tracker = RutOSDeviceTracker(mock_coordinator)
+        assert tracker.latitude == 37.7749
+
+    def test_longitude(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Test longitude from GPS data."""
+        tracker = RutOSDeviceTracker(mock_coordinator)
+        assert tracker.longitude == -122.4194
+
+    def test_location_accuracy(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Test location accuracy from GPS data."""
+        tracker = RutOSDeviceTracker(mock_coordinator)
+        assert tracker.location_accuracy == 5
+
+    def test_source_type(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Test source type is GPS."""
+        tracker = RutOSDeviceTracker(mock_coordinator)
+        assert tracker.source_type == SourceType.GPS
+
+    def test_unique_id(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Test unique_id is {serial}_gps_location."""
+        tracker = RutOSDeviceTracker(mock_coordinator)
+        assert tracker.unique_id == "1234567890_gps_location"
+
+    def test_no_gps_data_returns_none(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Test returns None when no GPS data available."""
+        mock_coordinator.data.gps_position = None
+        tracker = RutOSDeviceTracker(mock_coordinator)
+        assert tracker.latitude is None
+        assert tracker.longitude is None
+        assert tracker.location_accuracy == 0

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -70,6 +70,7 @@ def mock_api_instance():
     api.get_device_info.return_value = MOCK_DEVICE_INFO
     api.get_wan_interfaces.return_value = MOCK_WAN_INTERFACES
     api.get_internet_status.return_value = True
+    api.get_gps_position.return_value = None
     api.set_failover_order.return_value = None
     return api
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -11,8 +11,10 @@ from homeassistant.core import HomeAssistant
 from custom_components.rutos.const import DOMAIN
 from custom_components.rutos.coordinator import RutOSData, RutOSDataUpdateCoordinator
 from custom_components.rutos.sensor import (
+    GPS_SENSORS,
     INTERFACE_SENSORS,
     RutOSActiveWANSensor,
+    RutOSGPSSensorEntity,
     RutOSSensorEntity,
 )
 
@@ -124,3 +126,64 @@ class TestRutOSActiveWANSensor:
         """Test unique_id is {serial}_active_wan."""
         sensor = RutOSActiveWANSensor(mock_coordinator)
         assert sensor.unique_id == "1234567890_active_wan"
+
+
+class TestRutOSGPSSensorEntity:
+    """Tests for GPS sensor entities."""
+
+    def test_speed_sensor_value(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Test GPS speed sensor returns speed from GPS data."""
+        desc = GPS_SENSORS[0]  # speed
+        sensor = RutOSGPSSensorEntity(mock_coordinator, desc)
+        assert sensor.native_value == 65.3
+
+    def test_altitude_sensor_value(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Test GPS altitude sensor returns altitude from GPS data."""
+        desc = GPS_SENSORS[1]  # altitude
+        sensor = RutOSGPSSensorEntity(mock_coordinator, desc)
+        assert sensor.native_value == 15.2
+
+    def test_satellites_sensor_value(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Test GPS satellites sensor returns count."""
+        desc = GPS_SENSORS[2]  # satellites
+        sensor = RutOSGPSSensorEntity(mock_coordinator, desc)
+        assert sensor.native_value == 12
+
+    def test_heading_sensor_value(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Test GPS heading sensor returns angle."""
+        desc = GPS_SENSORS[3]  # heading
+        sensor = RutOSGPSSensorEntity(mock_coordinator, desc)
+        assert sensor.native_value == 180
+
+    def test_fix_status_sensor_value(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Test GPS fix status sensor returns fix type."""
+        desc = GPS_SENSORS[4]  # fix_status
+        sensor = RutOSGPSSensorEntity(mock_coordinator, desc)
+        assert sensor.native_value == "3D"
+
+    def test_no_gps_returns_none(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Test GPS sensor returns None when no GPS data."""
+        mock_coordinator.data.gps_position = None
+        desc = GPS_SENSORS[0]
+        sensor = RutOSGPSSensorEntity(mock_coordinator, desc)
+        assert sensor.native_value is None
+
+    def test_unique_id_format(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Test unique_id follows {serial}_{key} pattern."""
+        desc = GPS_SENSORS[0]
+        sensor = RutOSGPSSensorEntity(mock_coordinator, desc)
+        assert sensor.unique_id == "1234567890_gps_speed"


### PR DESCRIPTION
Adds a device_tracker entity that plots the router's GPS position on
the HA map, plus sensors for speed, altitude, heading, satellites, and
fix status. The GPS data is fetched in parallel with existing polls.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>