### PR TITLE
Fix TypeError in mobile data sensors

### DIFF
--- a/custom_components/rutos/api.py
+++ b/custom_components/rutos/api.py
@@ -263,10 +263,10 @@ class RutOSAPI:
                     "id": entry.get("id", ""),
                     "interface": entry.get("interface", ""),
                     "enabled": entry.get("enabled", False),
-                    "data_limit": entry.get("data_limit", 0),
-                    "data_used": entry.get("data_used", 0),
+                    "data_limit": int(entry.get("data_limit", 0)),
+                    "data_used": int(entry.get("data_used", 0)),
                     "data_warning_enabled": entry.get("data_warning_enabled", False),
-                    "data_warning_limit": entry.get("data_warning_limit", 0),
+                    "data_warning_limit": int(entry.get("data_warning_limit", 0)),
                     "due_reset_time": entry.get("due_reset_time"),
                 }
             )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -752,6 +752,32 @@ class TestGetDataLimit:
             assert result[0]["data_used"] == 2500000000
             assert result[0]["data_limit"] == 5000000000
 
+    async def test_get_data_limit_converts_string_values(self, api_client):
+        """Test that string numeric values from API are converted to int."""
+        data = [
+            {
+                "id": "limit1",
+                "interface": "mob1s1a1",
+                "enabled": True,
+                "data_limit": "5000000000",
+                "data_used": "2500000000",
+                "data_warning_enabled": True,
+                "data_warning_limit": "4000000000",
+                "due_reset_time": 1735689600,
+            },
+        ]
+        with aioresponses() as m:
+            m.post(_url("/login"), payload=_login_success())
+            m.get(_url("/data_limit/status"), payload=_success(data))
+
+            result = await api_client.get_data_limit()
+
+            assert result[0]["data_used"] == 2500000000
+            assert result[0]["data_limit"] == 5000000000
+            assert result[0]["data_warning_limit"] == 4000000000
+            assert isinstance(result[0]["data_used"], int)
+            assert isinstance(result[0]["data_limit"], int)
+
     async def test_get_data_limit_empty(self, api_client):
         """Test returns empty list when no limits configured."""
         with aioresponses() as m:


### PR DESCRIPTION
## Summary
- The RutOS API returns `data_used`, `data_limit`, and `data_warning_limit` as strings, but `data_usage_percent` performs arithmetic on them, causing a `TypeError: unsupported operand type(s) for /: 'str' and 'int'`
- Fix: cast these values to `int` in `api.py:get_data_limit()` at the parsing boundary
- Added regression test with string-valued API responses

Closes #11

## Test plan
- [x] All 138 tests pass
- [x] New test `test_get_data_limit_converts_string_values` verifies string→int conversion

🤖 Generated with [Claude Code](https://claude.com/claude-code)