### PR TITLE
Add mobile operator and roaming sensors

### DIFF
--- a/custom_components/rutos/api.py
+++ b/custom_components/rutos/api.py
@@ -325,6 +325,31 @@ class RutOSAPI:
             )
         return modems
 
+    async def get_modem_status(self) -> list[dict[str, Any]]:
+        """Fetch operator and roaming status for all modems."""
+        try:
+            data = await self.get("/modems/status")
+        except RutOSAPIError:
+            return []
+
+        if not isinstance(data, list):
+            return []
+
+        modems: list[dict[str, Any]] = []
+        for modem in data:
+            if not isinstance(modem, dict):
+                continue
+            modem_id = modem.get("id", "")
+            operator_state = str(modem.get("operator_state", ""))
+            modems.append(
+                {
+                    "id": modem_id,
+                    "operator": modem.get("operator"),
+                    "roaming": "roaming" in operator_state.lower(),
+                }
+            )
+        return modems
+
     async def set_failover_order(self, interfaces: list[str]) -> None:
         """Set the failover order by updating interface metrics."""
         for idx, iface_id in enumerate(interfaces):

--- a/custom_components/rutos/binary_sensor.py
+++ b/custom_components/rutos/binary_sensor.py
@@ -21,7 +21,11 @@ async def async_setup_entry(
 ) -> None:
     """Set up RutOS binary sensors based on a config entry."""
     coordinator: RutOSDataUpdateCoordinator = entry.runtime_data
-    async_add_entities([RutOSInternetConnectivitySensor(coordinator)])
+    entities: list[BinarySensorEntity] = [RutOSInternetConnectivitySensor(coordinator)]
+    for modem in coordinator.data.modem_status:
+        modem_id = modem.get("id", "")
+        entities.append(RutOSModemRoamingSensor(coordinator, modem_id))
+    async_add_entities(entities)
 
 
 class RutOSInternetConnectivitySensor(RutOSEntity, BinarySensorEntity):
@@ -41,3 +45,26 @@ class RutOSInternetConnectivitySensor(RutOSEntity, BinarySensorEntity):
     def is_on(self) -> bool:
         """Return true if internet is available."""
         return self.coordinator.data.internet_available
+
+
+class RutOSModemRoamingSensor(RutOSEntity, BinarySensorEntity):
+    """Binary sensor for modem roaming status."""
+
+    _attr_translation_key = "modem_roaming"
+
+    def __init__(self, coordinator: RutOSDataUpdateCoordinator, modem_id: str) -> None:
+        """Initialize the roaming binary sensor."""
+        super().__init__(coordinator)
+        self._modem_id = modem_id
+        self._attr_unique_id = (
+            f"{coordinator.data.device_info.get('serial', '')}_{modem_id}_roaming"
+        )
+        self._attr_translation_placeholders = {"modem": modem_id}
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if modem is roaming."""
+        for modem in self.coordinator.data.modem_status:
+            if modem.get("id") == self._modem_id:
+                return modem.get("roaming")
+        return None

--- a/custom_components/rutos/coordinator.py
+++ b/custom_components/rutos/coordinator.py
@@ -27,6 +27,7 @@ class RutOSData:
     gps_position: dict[str, Any] | None = None
     data_limit: list[dict[str, Any]] = field(default_factory=list)
     modem_signal: list[dict[str, Any]] = field(default_factory=list)
+    modem_status: list[dict[str, Any]] = field(default_factory=list)
     modems: list[dict[str, Any]] = field(default_factory=list)
 
 
@@ -68,6 +69,7 @@ class RutOSDataUpdateCoordinator(DataUpdateCoordinator[RutOSData]):
                 gps_position,
                 data_limit,
                 modem_signal,
+                modem_status,
                 modems,
             ) = await asyncio.gather(
                 self.api.get_wan_interfaces(),
@@ -75,6 +77,7 @@ class RutOSDataUpdateCoordinator(DataUpdateCoordinator[RutOSData]):
                 self.api.get_gps_position(),
                 self.api.get_data_limit(),
                 self.api.get_modem_signal(),
+                self.api.get_modem_status(),
                 self.api.get_modems(),
             )
         except RutOSAuthError as err:
@@ -87,5 +90,6 @@ class RutOSDataUpdateCoordinator(DataUpdateCoordinator[RutOSData]):
         self.data.gps_position = gps_position
         self.data.data_limit = data_limit
         self.data.modem_signal = modem_signal
+        self.data.modem_status = modem_status
         self.data.modems = modems
         return self.data

--- a/custom_components/rutos/sensor.py
+++ b/custom_components/rutos/sensor.py
@@ -184,6 +184,14 @@ MODEM_SIGNAL_SENSORS: tuple[RutOSSensorEntityDescription, ...] = (
     ),
 )
 
+MODEM_STATUS_SENSORS: tuple[RutOSSensorEntityDescription, ...] = (
+    RutOSSensorEntityDescription(
+        key="operator",
+        translation_key="modem_operator",
+        value_fn=lambda m: m.get("operator"),
+    ),
+)
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -212,6 +220,12 @@ async def async_setup_entry(
         entities.extend(
             RutOSModemSignalSensor(coordinator, desc, modem_id)
             for desc in MODEM_SIGNAL_SENSORS
+        )
+    for modem in coordinator.data.modem_status:
+        modem_id = modem.get("id", "")
+        entities.extend(
+            RutOSModemStatusSensor(coordinator, desc, modem_id)
+            for desc in MODEM_STATUS_SENSORS
         )
     async_add_entities(entities)
 
@@ -324,6 +338,40 @@ class RutOSModemSignalSensor(RutOSEntity, SensorEntity):
     def _find_modem(self) -> dict[str, Any] | None:
         """Find modem data by id."""
         for modem in self.coordinator.data.modem_signal:
+            if modem.get("id") == self._modem_id:
+                return modem
+        return None
+
+    @property
+    def native_value(self) -> str | int | float | None:
+        """Return the sensor value."""
+        modem = self._find_modem()
+        if modem is None:
+            return None
+        return self.entity_description.value_fn(modem)
+
+
+class RutOSModemStatusSensor(RutOSEntity, SensorEntity):
+    """Representation of a RutOS modem status sensor."""
+
+    entity_description: RutOSSensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: RutOSDataUpdateCoordinator,
+        description: RutOSSensorEntityDescription,
+        modem_id: str,
+    ) -> None:
+        """Initialize the modem status sensor."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._modem_id = modem_id
+        self._attr_unique_id = f"{coordinator.data.device_info.get('serial', '')}_{modem_id}_{description.key}"
+        self._attr_translation_placeholders = {"modem": modem_id}
+
+    def _find_modem(self) -> dict[str, Any] | None:
+        """Find modem data by id."""
+        for modem in self.coordinator.data.modem_status:
             if modem.get("id") == self._modem_id:
                 return modem
         return None

--- a/custom_components/rutos/translations/en.json
+++ b/custom_components/rutos/translations/en.json
@@ -96,6 +96,9 @@
       },
       "modem_band": {
         "name": "{modem} band"
+      },
+      "modem_operator": {
+        "name": "{modem} operator"
       }
     },
     "button": {
@@ -109,6 +112,9 @@
     "binary_sensor": {
       "internet_connectivity": {
         "name": "Internet connectivity"
+      },
+      "modem_roaming": {
+        "name": "{modem} roaming"
       }
     },
     "switch": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,13 +112,19 @@ def mock_modem_signal() -> list[dict]:
 
 
 @pytest.fixture
+def mock_modem_status() -> list[dict]:
+    """Return mock modem status data."""
+    return [{"id": "modem1", "operator": "T-Mobile", "roaming": False}]
+
+
+@pytest.fixture
 def mock_modems() -> list[dict]:
     """Return mock modem list."""
     return [{"id": "modem1"}]
 
 
 @pytest.fixture
-def mock_rutos_data(mock_device_info, mock_wan_interfaces, mock_gps_position, mock_data_limit, mock_modem_signal, mock_modems) -> RutOSData:
+def mock_rutos_data(mock_device_info, mock_wan_interfaces, mock_gps_position, mock_data_limit, mock_modem_signal, mock_modem_status, mock_modems) -> RutOSData:
     """Return a populated RutOSData instance."""
     return RutOSData(
         device_info=mock_device_info,
@@ -127,6 +133,7 @@ def mock_rutos_data(mock_device_info, mock_wan_interfaces, mock_gps_position, mo
         gps_position=mock_gps_position,
         data_limit=mock_data_limit,
         modem_signal=mock_modem_signal,
+        modem_status=mock_modem_status,
         modems=mock_modems,
     )
 
@@ -173,6 +180,9 @@ def mock_api(mock_device_info, mock_wan_interfaces) -> AsyncMock:
             "band": "B7",
             "channel_number": 3100,
         },
+    ]
+    api.get_modem_status.return_value = [
+        {"id": "modem1", "operator": "T-Mobile", "roaming": False},
     ]
     api.get_modems.return_value = [{"id": "modem1"}]
     api.reboot_modem.return_value = None

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -944,3 +944,76 @@ class TestGetModemSignal:
 
             result = await api_client.get_modem_signal()
             assert result == []
+
+
+class TestGetModemStatus:
+    """Tests for get_modem_status."""
+
+    async def test_get_modem_status_home(self, api_client):
+        """Test parsing of modem status response with home network."""
+        status_data = [
+            {
+                "id": "2-1",
+                "operator": "Bell",
+                "operator_state": "Registered, home",
+            },
+        ]
+        with aioresponses() as m:
+            m.post(_url("/login"), payload=_login_success())
+            m.get(_url("/modems/status"), payload=_success(status_data))
+
+            result = await api_client.get_modem_status()
+
+            assert len(result) == 1
+            assert result[0]["id"] == "2-1"
+            assert result[0]["operator"] == "Bell"
+            assert result[0]["roaming"] is False
+
+    async def test_get_modem_status_roaming(self, api_client):
+        """Test roaming detection from operator_state."""
+        status_data = [
+            {
+                "id": "2-1",
+                "operator": "AT&T",
+                "operator_state": "Registered, roaming",
+            },
+        ]
+        with aioresponses() as m:
+            m.post(_url("/login"), payload=_login_success())
+            m.get(_url("/modems/status"), payload=_success(status_data))
+
+            result = await api_client.get_modem_status()
+
+            assert len(result) == 1
+            assert result[0]["operator"] == "AT&T"
+            assert result[0]["roaming"] is True
+
+    async def test_get_modem_status_empty(self, api_client):
+        """Test returns empty list when no modems."""
+        with aioresponses() as m:
+            m.post(_url("/login"), payload=_login_success())
+            m.get(_url("/modems/status"), payload=_success([]))
+
+            result = await api_client.get_modem_status()
+            assert result == []
+
+    async def test_get_modem_status_api_error(self, api_client):
+        """Test returns empty list on API error."""
+        with aioresponses() as m:
+            m.post(_url("/login"), payload=_login_success())
+            m.get(
+                _url("/modems/status"),
+                payload=_error("Service unavailable"),
+            )
+
+            result = await api_client.get_modem_status()
+            assert result == []
+
+    async def test_get_modem_status_non_list(self, api_client):
+        """Test returns empty list for non-list response."""
+        with aioresponses() as m:
+            m.post(_url("/login"), payload=_login_success())
+            m.get(_url("/modems/status"), payload=_success({"unexpected": True}))
+
+            result = await api_client.get_modem_status()
+            assert result == []

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 
-from custom_components.rutos.binary_sensor import RutOSInternetConnectivitySensor
+from custom_components.rutos.binary_sensor import (
+    RutOSInternetConnectivitySensor,
+    RutOSModemRoamingSensor,
+)
 from custom_components.rutos.coordinator import RutOSDataUpdateCoordinator
 
 
@@ -40,3 +43,41 @@ class TestRutOSInternetConnectivitySensor:
         """Test unique_id is {serial}_internet_connectivity."""
         sensor = RutOSInternetConnectivitySensor(mock_coordinator)
         assert sensor.unique_id == "1234567890_internet_connectivity"
+
+
+class TestRutOSModemRoamingSensor:
+    """Tests for the modem roaming binary sensor."""
+
+    def test_is_off_when_not_roaming(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Test is_on is False when not roaming."""
+        mock_coordinator.data.modem_status = [
+            {"id": "modem1", "operator": "T-Mobile", "roaming": False},
+        ]
+        sensor = RutOSModemRoamingSensor(mock_coordinator, "modem1")
+        assert sensor.is_on is False
+
+    def test_is_on_when_roaming(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Test is_on is True when roaming."""
+        mock_coordinator.data.modem_status = [
+            {"id": "modem1", "operator": "AT&T", "roaming": True},
+        ]
+        sensor = RutOSModemRoamingSensor(mock_coordinator, "modem1")
+        assert sensor.is_on is True
+
+    def test_missing_modem_returns_none(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Test returns None when modem not found."""
+        sensor = RutOSModemRoamingSensor(mock_coordinator, "nonexistent")
+        assert sensor.is_on is None
+
+    def test_unique_id(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Test unique_id follows {serial}_{modem}_roaming pattern."""
+        sensor = RutOSModemRoamingSensor(mock_coordinator, "modem1")
+        assert sensor.unique_id == "1234567890_modem1_roaming"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -12,10 +12,12 @@ from custom_components.rutos.sensor import (
     DATA_LIMIT_SENSORS,
     INTERFACE_SENSORS,
     MODEM_SIGNAL_SENSORS,
+    MODEM_STATUS_SENSORS,
     RutOSActiveWANSensor,
     RutOSGPSSensorEntity,
     RutOSDataLimitSensor,
     RutOSModemSignalSensor,
+    RutOSModemStatusSensor,
     RutOSSensorEntity,
 )
 
@@ -333,3 +335,31 @@ class TestRutOSModemSignalSensor:
         desc = MODEM_SIGNAL_SENSORS[0]
         sensor = RutOSModemSignalSensor(mock_coordinator, desc, "modem1")
         assert sensor.unique_id == "1234567890_modem1_rssi"
+
+
+class TestRutOSModemStatusSensor:
+    """Tests for modem status (operator) sensor entities."""
+
+    def test_operator_value(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Test operator sensor returns carrier name."""
+        desc = MODEM_STATUS_SENSORS[0]  # operator
+        sensor = RutOSModemStatusSensor(mock_coordinator, desc, "modem1")
+        assert sensor.native_value == "T-Mobile"
+
+    def test_missing_modem_returns_none(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Test returns None when modem not found."""
+        desc = MODEM_STATUS_SENSORS[0]
+        sensor = RutOSModemStatusSensor(mock_coordinator, desc, "nonexistent")
+        assert sensor.native_value is None
+
+    def test_unique_id_format(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Test unique_id follows {serial}_{modem}_{key} pattern."""
+        desc = MODEM_STATUS_SENSORS[0]
+        sensor = RutOSModemStatusSensor(mock_coordinator, desc, "modem1")
+        assert sensor.unique_id == "1234567890_modem1_operator"


### PR DESCRIPTION
## Summary
- Add `get_modem_status()` API method to fetch operator and roaming data from `/modems/status`
- Add operator sensor (per modem) showing the connected carrier name
- Add roaming binary sensor (per modem) indicating home vs roaming network
- Full test coverage for API parsing, sensor values, and binary sensor on/off states

## Test plan
- [x] `ruff check` passes (no new lint issues)
- [x] `ruff format` passes
- [x] All 150 tests pass (`pytest tests/ -v`)
- [x] `pyright` — no new type errors (existing `asyncio.gather` inference issues only)
- [ ] Manual verification on a router with modem returning `/modems/status` data

🤖 Generated with [Claude Code](https://claude.com/claude-code)