### PR TITLE
Optimization: align with HA best practices

### DIFF
--- a/custom_components/rutos/__init__.py
+++ b/custom_components/rutos/__init__.py
@@ -2,28 +2,21 @@
 
 from __future__ import annotations
 
-import logging
-
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import Platform
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .api import RutOSAPI
 from .const import (
     ATTR_INTERFACES,
-    CONF_HOST,
-    CONF_PASSWORD,
     CONF_UPDATE_HOME_LOCATION,
-    CONF_USERNAME,
     DOMAIN,
     SERVICE_SET_FAILOVER_ORDER,
 )
 from .coordinator import RutOSDataUpdateCoordinator
-
-_LOGGER = logging.getLogger(__name__)
 
 PLATFORMS: list[Platform] = [
     Platform.SENSOR,
@@ -45,7 +38,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: RutOSConfigEntry) -> boo
         session=session,
     )
 
-    coordinator = RutOSDataUpdateCoordinator(hass, api)
+    coordinator = RutOSDataUpdateCoordinator(hass, entry, api)
     await coordinator.async_config_entry_first_refresh()
 
     entry.runtime_data = coordinator
@@ -60,7 +53,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: RutOSConfigEntry) -> boo
 
 async def async_unload_entry(hass: HomeAssistant, entry: RutOSConfigEntry) -> bool:
     """Unload a config entry."""
-    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+    # Remove services when last config entry is unloaded
+    if unload_ok and not hass.config_entries.async_loaded_entries(DOMAIN):
+        hass.services.async_remove(DOMAIN, SERVICE_SET_FAILOVER_ORDER)
+
+    return unload_ok
 
 
 def _register_home_location_listener(

--- a/custom_components/rutos/api.py
+++ b/custom_components/rutos/api.py
@@ -128,7 +128,6 @@ class RutOSAPI:
                 json=payload,
                 ssl=False,
             ) as resp:
-                status = resp.status
                 try:
                     data = await resp.json(content_type=None)
                 except (ValueError, aiohttp.ContentTypeError):

--- a/custom_components/rutos/binary_sensor.py
+++ b/custom_components/rutos/binary_sensor.py
@@ -6,17 +6,17 @@ from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from . import RutOSConfigEntry
 from .coordinator import RutOSDataUpdateCoordinator
 from .entity import RutOSEntity
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: RutOSConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up RutOS binary sensors based on a config entry."""

--- a/custom_components/rutos/button.py
+++ b/custom_components/rutos/button.py
@@ -3,17 +3,17 @@
 from __future__ import annotations
 
 from homeassistant.components.button import ButtonEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from . import RutOSConfigEntry
 from .coordinator import RutOSDataUpdateCoordinator
 from .entity import RutOSEntity
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: RutOSConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up RutOS buttons based on a config entry."""

--- a/custom_components/rutos/config_flow.py
+++ b/custom_components/rutos/config_flow.py
@@ -8,19 +8,18 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant.config_entries import (
+    ConfigEntry,
     ConfigFlow,
     ConfigFlowResult,
     OptionsFlow,
 )
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .api import RutOSAPI, RutOSAuthError, RutOSConnectionError
 from .const import (
-    CONF_HOST,
-    CONF_PASSWORD,
     CONF_UPDATE_HOME_LOCATION,
-    CONF_USERNAME,
     DEFAULT_USERNAME,
     DOMAIN,
 )
@@ -44,7 +43,7 @@ class RutOSConfigFlow(ConfigFlow, domain=DOMAIN):
     @staticmethod
     @callback
     def async_get_options_flow(
-        config_entry: ConfigFlow,
+        config_entry: ConfigEntry,
     ) -> RutOSOptionsFlowHandler:
         """Get the options flow for this handler."""
         return RutOSOptionsFlowHandler()

--- a/custom_components/rutos/const.py
+++ b/custom_components/rutos/const.py
@@ -2,10 +2,6 @@
 
 DOMAIN = "rutos"
 
-CONF_HOST = "host"
-CONF_USERNAME = "username"
-CONF_PASSWORD = "password"
-
 DEFAULT_USERNAME = "admin"
 DEFAULT_SCAN_INTERVAL = 30
 

--- a/custom_components/rutos/coordinator.py
+++ b/custom_components/rutos/coordinator.py
@@ -6,8 +6,9 @@ import asyncio
 from dataclasses import dataclass, field
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, cast
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -34,11 +35,12 @@ class RutOSData:
 class RutOSDataUpdateCoordinator(DataUpdateCoordinator[RutOSData]):
     """Coordinator to manage fetching RutOS data."""
 
-    def __init__(self, hass: HomeAssistant, api: RutOSAPI) -> None:
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry, api: RutOSAPI) -> None:
         """Initialize the coordinator."""
         super().__init__(
             hass,
             _LOGGER,
+            config_entry=entry,
             name=DOMAIN,
             update_interval=timedelta(seconds=DEFAULT_SCAN_INTERVAL),
         )
@@ -62,34 +64,40 @@ class RutOSDataUpdateCoordinator(DataUpdateCoordinator[RutOSData]):
         if self.data is None:
             self.data = RutOSData()
 
+        _ResultT = tuple[
+            list[dict[str, Any]],
+            bool,
+            dict[str, Any] | None,
+            list[dict[str, Any]],
+            list[dict[str, Any]],
+            list[dict[str, Any]],
+            list[dict[str, Any]],
+        ]
         try:
-            (
-                wan_interfaces,
-                internet_available,
-                gps_position,
-                data_limit,
-                modem_signal,
-                modem_status,
-                modems,
-            ) = await asyncio.gather(
-                self.api.get_wan_interfaces(),
-                self.api.get_internet_status(),
-                self.api.get_gps_position(),
-                self.api.get_data_limit(),
-                self.api.get_modem_signal(),
-                self.api.get_modem_status(),
-                self.api.get_modems(),
+            results = cast(
+                _ResultT,
+                await asyncio.gather(
+                    self.api.get_wan_interfaces(),
+                    self.api.get_internet_status(),
+                    self.api.get_gps_position(),
+                    self.api.get_data_limit(),
+                    self.api.get_modem_signal(),
+                    self.api.get_modem_status(),
+                    self.api.get_modems(),
+                ),
             )
         except RutOSAuthError as err:
             raise UpdateFailed(f"Authentication failed: {err}") from err
         except RutOSAPIError as err:
             raise UpdateFailed(f"Error communicating with API: {err}") from err
 
-        self.data.wan_interfaces = wan_interfaces
-        self.data.internet_available = internet_available
-        self.data.gps_position = gps_position
-        self.data.data_limit = data_limit
-        self.data.modem_signal = modem_signal
-        self.data.modem_status = modem_status
-        self.data.modems = modems
+        (
+            self.data.wan_interfaces,
+            self.data.internet_available,
+            self.data.gps_position,
+            self.data.data_limit,
+            self.data.modem_signal,
+            self.data.modem_status,
+            self.data.modems,
+        ) = results
         return self.data

--- a/custom_components/rutos/entity.py
+++ b/custom_components/rutos/entity.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
@@ -16,17 +17,17 @@ class RutOSEntity(CoordinatorEntity[RutOSDataUpdateCoordinator]):
     _attr_has_entity_name = True
 
     @property
-    def device_info(self) -> dict[str, Any]:
+    def device_info(self) -> DeviceInfo:
         """Return device info."""
         info = self.coordinator.data.device_info
         serial = info.get("serial", "")
-        return {
-            "identifiers": {(DOMAIN, serial)},
-            "name": info.get("model", "RutOS Device"),
-            "manufacturer": "Teltonika",
-            "model": info.get("name", ""),
-            "sw_version": info.get("firmware", ""),
-        }
+        return DeviceInfo(
+            identifiers={(DOMAIN, serial)},
+            name=info.get("model", "RutOS Device"),
+            manufacturer="Teltonika",
+            model=info.get("name", ""),
+            sw_version=info.get("firmware", ""),
+        )
 
     def _find_interface(self, interface_name: str) -> dict[str, Any] | None:
         """Find a WAN interface by name, or return None."""

--- a/custom_components/rutos/sensor.py
+++ b/custom_components/rutos/sensor.py
@@ -12,10 +12,10 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from . import RutOSConfigEntry
 from .coordinator import RutOSDataUpdateCoordinator
 from .entity import RutOSEntity
 
@@ -195,7 +195,7 @@ MODEM_STATUS_SENSORS: tuple[RutOSSensorEntityDescription, ...] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: RutOSConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up RutOS sensors based on a config entry."""

--- a/custom_components/rutos/strings.json
+++ b/custom_components/rutos/strings.json
@@ -20,6 +20,15 @@
       "already_configured": "This device is already configured."
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "update_home_location": "Update Home Assistant home location from GPS"
+        }
+      }
+    }
+  },
   "entity": {
     "sensor": {
       "wan_status": {
@@ -36,11 +45,76 @@
       },
       "active_wan": {
         "name": "Active WAN interface"
+      },
+      "gps_latitude": {
+        "name": "GPS latitude"
+      },
+      "gps_longitude": {
+        "name": "GPS longitude"
+      },
+      "gps_speed": {
+        "name": "GPS speed"
+      },
+      "gps_altitude": {
+        "name": "GPS altitude"
+      },
+      "gps_satellites": {
+        "name": "GPS satellites"
+      },
+      "gps_heading": {
+        "name": "GPS heading"
+      },
+      "gps_fix_status": {
+        "name": "GPS fix status"
+      },
+      "gps_accuracy": {
+        "name": "GPS accuracy"
+      },
+      "data_used": {
+        "name": "{limit} data used"
+      },
+      "data_limit": {
+        "name": "{limit} data limit"
+      },
+      "data_usage_percent": {
+        "name": "{limit} data usage"
+      },
+      "modem_rssi": {
+        "name": "{modem} RSSI"
+      },
+      "modem_rsrp": {
+        "name": "{modem} RSRP"
+      },
+      "modem_rsrq": {
+        "name": "{modem} RSRQ"
+      },
+      "modem_sinr": {
+        "name": "{modem} SINR"
+      },
+      "modem_network_type": {
+        "name": "{modem} network type"
+      },
+      "modem_band": {
+        "name": "{modem} band"
+      },
+      "modem_operator": {
+        "name": "{modem} operator"
+      }
+    },
+    "button": {
+      "clear_data_usage": {
+        "name": "Clear data usage"
+      },
+      "modem_reboot": {
+        "name": "Reboot {modem}"
       }
     },
     "binary_sensor": {
       "internet_connectivity": {
         "name": "Internet connectivity"
+      },
+      "modem_roaming": {
+        "name": "{modem} roaming"
       }
     },
     "switch": {

--- a/custom_components/rutos/switch.py
+++ b/custom_components/rutos/switch.py
@@ -5,17 +5,17 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.switch import SwitchEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from . import RutOSConfigEntry
 from .coordinator import RutOSDataUpdateCoordinator
 from .entity import RutOSEntity
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: RutOSConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up RutOS switches based on a config entry."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,9 @@ import pytest
 from homeassistant.core import HomeAssistant
 
 from custom_components.rutos.api import RutOSAPI
-from custom_components.rutos.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME, DOMAIN
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+
+from custom_components.rutos.const import DOMAIN
 from custom_components.rutos.coordinator import RutOSData, RutOSDataUpdateCoordinator
 
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -124,7 +126,15 @@ def mock_modems() -> list[dict]:
 
 
 @pytest.fixture
-def mock_rutos_data(mock_device_info, mock_wan_interfaces, mock_gps_position, mock_data_limit, mock_modem_signal, mock_modem_status, mock_modems) -> RutOSData:
+def mock_rutos_data(
+    mock_device_info,
+    mock_wan_interfaces,
+    mock_gps_position,
+    mock_data_limit,
+    mock_modem_signal,
+    mock_modem_status,
+    mock_modems,
+) -> RutOSData:
     """Return a populated RutOSData instance."""
     return RutOSData(
         device_info=mock_device_info,
@@ -210,9 +220,11 @@ def mock_config_entry() -> MockConfigEntry:
 def mock_coordinator(
     hass: HomeAssistant,
     mock_api: AsyncMock,
+    mock_config_entry: MockConfigEntry,
     mock_rutos_data: RutOSData,
 ) -> RutOSDataUpdateCoordinator:
     """Return a coordinator with mocked API and pre-populated data."""
-    coordinator = RutOSDataUpdateCoordinator(hass, mock_api)
+    mock_config_entry.add_to_hass(hass)
+    coordinator = RutOSDataUpdateCoordinator(hass, mock_config_entry, mock_api)
     coordinator.data = mock_rutos_data
     return coordinator

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -65,7 +65,9 @@ def _success(data=None):
     return {"success": True, "data": data}
 
 
-def _error(error: str = "Something went wrong", source: str = "General", code: int = 100):
+def _error(
+    error: str = "Something went wrong", source: str = "General", code: int = 100
+):
     """Return an error API response."""
     return {
         "success": False,
@@ -267,7 +269,7 @@ class TestEnsureSession:
         with aioresponses() as m:
             m.post(_url("/login"), payload=_login_success())
 
-            results = await asyncio.gather(
+            await asyncio.gather(
                 api_client._ensure_session(),
                 api_client._ensure_session(),
                 api_client._ensure_session(),
@@ -461,11 +463,13 @@ class TestGetInternetStatus:
             m.post(_url("/login"), payload=_login_success())
             m.get(
                 _url("/internet_connection/status"),
-                payload=_success({
-                    "ipv4_status": "connected",
-                    "ipv6_status": "disconnected",
-                    "dns_status": "connected",
-                }),
+                payload=_success(
+                    {
+                        "ipv4_status": "connected",
+                        "ipv6_status": "disconnected",
+                        "dns_status": "connected",
+                    }
+                ),
             )
 
             assert await api_client.get_internet_status() is True
@@ -476,11 +480,13 @@ class TestGetInternetStatus:
             m.post(_url("/login"), payload=_login_success())
             m.get(
                 _url("/internet_connection/status"),
-                payload=_success({
-                    "ipv4_status": "disconnected",
-                    "ipv6_status": "disconnected",
-                    "dns_status": "disconnected",
-                }),
+                payload=_success(
+                    {
+                        "ipv4_status": "disconnected",
+                        "ipv6_status": "disconnected",
+                        "dns_status": "disconnected",
+                    }
+                ),
             )
 
             assert await api_client.get_internet_status() is False
@@ -550,7 +556,9 @@ class TestSetFailoverOrder:
             assert len(put_requests) == 2
 
             # First interface gets metric 10
-            wan_put = next(p for p in put_requests if "wan" in p[0] and "mob" not in p[0])
+            wan_put = next(
+                p for p in put_requests if "wan" in p[0] and "mob" not in p[0]
+            )
             assert wan_put[1] == {"data": {"metric": "10"}}
 
             # Second interface gets metric 20
@@ -822,8 +830,7 @@ class TestClearDataUsage:
 
             # Verify the POST was sent
             post_count = sum(
-                1 for key in m.requests
-                if key[0] == "POST" and "clear" in str(key[1])
+                1 for key in m.requests if key[0] == "POST" and "clear" in str(key[1])
             )
             assert post_count == 1
 
@@ -840,8 +847,7 @@ class TestRebootModem:
             await api_client.reboot_modem("modem1")
 
             post_count = sum(
-                1 for key in m.requests
-                if key[0] == "POST" and "modem1" in str(key[1])
+                1 for key in m.requests if key[0] == "POST" and "modem1" in str(key[1])
             )
             assert post_count == 1
 

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -37,9 +37,7 @@ class TestRutOSInternetConnectivitySensor:
         sensor = RutOSInternetConnectivitySensor(mock_coordinator)
         assert sensor.device_class == BinarySensorDeviceClass.CONNECTIVITY
 
-    def test_unique_id(
-        self, mock_coordinator: RutOSDataUpdateCoordinator
-    ):
+    def test_unique_id(self, mock_coordinator: RutOSDataUpdateCoordinator):
         """Test unique_id is {serial}_internet_connectivity."""
         sensor = RutOSInternetConnectivitySensor(mock_coordinator)
         assert sensor.unique_id == "1234567890_internet_connectivity"
@@ -58,9 +56,7 @@ class TestRutOSModemRoamingSensor:
         sensor = RutOSModemRoamingSensor(mock_coordinator, "modem1")
         assert sensor.is_on is False
 
-    def test_is_on_when_roaming(
-        self, mock_coordinator: RutOSDataUpdateCoordinator
-    ):
+    def test_is_on_when_roaming(self, mock_coordinator: RutOSDataUpdateCoordinator):
         """Test is_on is True when roaming."""
         mock_coordinator.data.modem_status = [
             {"id": "modem1", "operator": "AT&T", "roaming": True},
@@ -75,9 +71,7 @@ class TestRutOSModemRoamingSensor:
         sensor = RutOSModemRoamingSensor(mock_coordinator, "nonexistent")
         assert sensor.is_on is None
 
-    def test_unique_id(
-        self, mock_coordinator: RutOSDataUpdateCoordinator
-    ):
+    def test_unique_id(self, mock_coordinator: RutOSDataUpdateCoordinator):
         """Test unique_id follows {serial}_{modem}_roaming pattern."""
         sensor = RutOSModemRoamingSensor(mock_coordinator, "modem1")
         assert sensor.unique_id == "1234567890_modem1_roaming"

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -7,23 +7,22 @@ from unittest.mock import AsyncMock
 import pytest
 
 from custom_components.rutos.api import RutOSAPIError
-from custom_components.rutos.button import RutOSClearDataUsageButton, RutOSModemRebootButton
+from custom_components.rutos.button import (
+    RutOSClearDataUsageButton,
+    RutOSModemRebootButton,
+)
 from custom_components.rutos.coordinator import RutOSDataUpdateCoordinator
 
 
 class TestRutOSClearDataUsageButton:
     """Tests for the clear data usage button."""
 
-    def test_unique_id(
-        self, mock_coordinator: RutOSDataUpdateCoordinator
-    ):
+    def test_unique_id(self, mock_coordinator: RutOSDataUpdateCoordinator):
         """Test unique_id is {serial}_clear_data_usage."""
         button = RutOSClearDataUsageButton(mock_coordinator)
         assert button.unique_id == "1234567890_clear_data_usage"
 
-    async def test_press_calls_api(
-        self, mock_coordinator: RutOSDataUpdateCoordinator
-    ):
+    async def test_press_calls_api(self, mock_coordinator: RutOSDataUpdateCoordinator):
         """Test pressing the button calls clear_data_usage + refresh."""
         mock_coordinator.async_request_refresh = AsyncMock()
         button = RutOSClearDataUsageButton(mock_coordinator)
@@ -37,16 +36,12 @@ class TestRutOSClearDataUsageButton:
 class TestRutOSModemRebootButton:
     """Tests for the modem reboot button."""
 
-    def test_unique_id(
-        self, mock_coordinator: RutOSDataUpdateCoordinator
-    ):
+    def test_unique_id(self, mock_coordinator: RutOSDataUpdateCoordinator):
         """Test unique_id is {serial}_{modem}_reboot."""
         button = RutOSModemRebootButton(mock_coordinator, "modem1")
         assert button.unique_id == "1234567890_modem1_reboot"
 
-    async def test_press_calls_api(
-        self, mock_coordinator: RutOSDataUpdateCoordinator
-    ):
+    async def test_press_calls_api(self, mock_coordinator: RutOSDataUpdateCoordinator):
         """Test pressing the button calls reboot_modem + refresh."""
         mock_coordinator.async_request_refresh = AsyncMock()
         button = RutOSModemRebootButton(mock_coordinator, "modem1")

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -4,22 +4,19 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, patch
 
-import pytest
 
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from custom_components.rutos.api import RutOSAuthError, RutOSConnectionError
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+
 from custom_components.rutos.const import (
-    CONF_HOST,
-    CONF_PASSWORD,
     CONF_UPDATE_HOME_LOCATION,
-    CONF_USERNAME,
     DOMAIN,
 )
 
-from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 USER_INPUT = {
     CONF_HOST: "192.168.1.1",
@@ -50,9 +47,7 @@ async def test_form_shown_on_init(hass: HomeAssistant):
 async def test_successful_config_flow(hass: HomeAssistant):
     """Test a complete successful config flow creates an entry."""
     with (
-        patch(
-            "custom_components.rutos.config_flow.RutOSAPI"
-        ) as mock_api_cls,
+        patch("custom_components.rutos.config_flow.RutOSAPI") as mock_api_cls,
         patch("custom_components.rutos.async_setup_entry", return_value=True),
     ):
         mock_api = AsyncMock()
@@ -75,9 +70,7 @@ async def test_successful_config_flow(hass: HomeAssistant):
 
 async def test_invalid_auth_error(hass: HomeAssistant):
     """Test RutOSAuthError shows invalid_auth error."""
-    with patch(
-        "custom_components.rutos.config_flow.RutOSAPI"
-    ) as mock_api_cls:
+    with patch("custom_components.rutos.config_flow.RutOSAPI") as mock_api_cls:
         mock_api = AsyncMock()
         mock_api.login.side_effect = RutOSAuthError("bad password")
         mock_api_cls.return_value = mock_api
@@ -95,9 +88,7 @@ async def test_invalid_auth_error(hass: HomeAssistant):
 
 async def test_cannot_connect_error(hass: HomeAssistant):
     """Test RutOSConnectionError shows cannot_connect error."""
-    with patch(
-        "custom_components.rutos.config_flow.RutOSAPI"
-    ) as mock_api_cls:
+    with patch("custom_components.rutos.config_flow.RutOSAPI") as mock_api_cls:
         mock_api = AsyncMock()
         mock_api.login.side_effect = RutOSConnectionError("refused")
         mock_api_cls.return_value = mock_api
@@ -115,9 +106,7 @@ async def test_cannot_connect_error(hass: HomeAssistant):
 
 async def test_unknown_error(hass: HomeAssistant):
     """Test unexpected exception shows unknown error."""
-    with patch(
-        "custom_components.rutos.config_flow.RutOSAPI"
-    ) as mock_api_cls:
+    with patch("custom_components.rutos.config_flow.RutOSAPI") as mock_api_cls:
         mock_api = AsyncMock()
         mock_api.login.side_effect = RuntimeError("oops")
         mock_api_cls.return_value = mock_api
@@ -137,9 +126,7 @@ async def test_duplicate_device_aborts(hass: HomeAssistant, mock_config_entry):
     """Test same serial number aborts with already_configured."""
     mock_config_entry.add_to_hass(hass)
 
-    with patch(
-        "custom_components.rutos.config_flow.RutOSAPI"
-    ) as mock_api_cls:
+    with patch("custom_components.rutos.config_flow.RutOSAPI") as mock_api_cls:
         mock_api = AsyncMock()
         mock_api.login.return_value = None
         mock_api.get_device_info.return_value = DEVICE_INFO
@@ -165,9 +152,7 @@ async def test_no_serial_creates_entry_without_unique_id(hass: HomeAssistant):
     }
 
     with (
-        patch(
-            "custom_components.rutos.config_flow.RutOSAPI"
-        ) as mock_api_cls,
+        patch("custom_components.rutos.config_flow.RutOSAPI") as mock_api_cls,
         patch("custom_components.rutos.async_setup_entry", return_value=True),
     ):
         mock_api = AsyncMock()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -14,12 +14,18 @@ from custom_components.rutos.api import RutOSAPIError, RutOSAuthError
 from custom_components.rutos.const import DEFAULT_SCAN_INTERVAL
 from custom_components.rutos.coordinator import RutOSData, RutOSDataUpdateCoordinator
 
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
 
 async def test_async_setup_fetches_device_info(
-    hass: HomeAssistant, mock_api: AsyncMock, mock_device_info: dict
+    hass: HomeAssistant,
+    mock_api: AsyncMock,
+    mock_device_info: dict,
+    mock_config_entry: MockConfigEntry,
 ):
     """Test _async_setup populates device_info."""
-    coordinator = RutOSDataUpdateCoordinator(hass, mock_api)
+    mock_config_entry.add_to_hass(hass)
+    coordinator = RutOSDataUpdateCoordinator(hass, mock_config_entry, mock_api)
     coordinator.data = RutOSData()
 
     await coordinator._async_setup()
@@ -29,22 +35,28 @@ async def test_async_setup_fetches_device_info(
 
 
 async def test_async_setup_auth_error_raises_update_failed(
-    hass: HomeAssistant, mock_api: AsyncMock
+    hass: HomeAssistant,
+    mock_api: AsyncMock,
+    mock_config_entry: MockConfigEntry,
 ):
     """Test API auth error during setup raises UpdateFailed."""
     mock_api.get_device_info.side_effect = RutOSAuthError("bad creds")
-    coordinator = RutOSDataUpdateCoordinator(hass, mock_api)
+    mock_config_entry.add_to_hass(hass)
+    coordinator = RutOSDataUpdateCoordinator(hass, mock_config_entry, mock_api)
 
     with pytest.raises(UpdateFailed, match="Authentication failed"):
         await coordinator._async_setup()
 
 
 async def test_async_setup_api_error_raises_update_failed(
-    hass: HomeAssistant, mock_api: AsyncMock
+    hass: HomeAssistant,
+    mock_api: AsyncMock,
+    mock_config_entry: MockConfigEntry,
 ):
     """Test generic API error during setup raises UpdateFailed."""
     mock_api.get_device_info.side_effect = RutOSAPIError("timeout")
-    coordinator = RutOSDataUpdateCoordinator(hass, mock_api)
+    mock_config_entry.add_to_hass(hass)
+    coordinator = RutOSDataUpdateCoordinator(hass, mock_config_entry, mock_api)
 
     with pytest.raises(UpdateFailed, match="Failed to get device info"):
         await coordinator._async_setup()
@@ -54,9 +66,11 @@ async def test_async_update_data_returns_rutos_data(
     hass: HomeAssistant,
     mock_api: AsyncMock,
     mock_wan_interfaces: list[dict],
+    mock_config_entry: MockConfigEntry,
 ):
     """Test _async_update_data returns populated RutOSData."""
-    coordinator = RutOSDataUpdateCoordinator(hass, mock_api)
+    mock_config_entry.add_to_hass(hass)
+    coordinator = RutOSDataUpdateCoordinator(hass, mock_config_entry, mock_api)
     coordinator.data = RutOSData()
 
     result = await coordinator._async_update_data()
@@ -81,11 +95,14 @@ async def test_async_update_data_returns_rutos_data(
 
 
 async def test_async_update_data_auth_error_raises_update_failed(
-    hass: HomeAssistant, mock_api: AsyncMock
+    hass: HomeAssistant,
+    mock_api: AsyncMock,
+    mock_config_entry: MockConfigEntry,
 ):
     """Test auth error during update raises UpdateFailed."""
     mock_api.get_wan_interfaces.side_effect = RutOSAuthError("expired")
-    coordinator = RutOSDataUpdateCoordinator(hass, mock_api)
+    mock_config_entry.add_to_hass(hass)
+    coordinator = RutOSDataUpdateCoordinator(hass, mock_config_entry, mock_api)
     coordinator.data = RutOSData()
 
     with pytest.raises(UpdateFailed, match="Authentication failed"):
@@ -93,28 +110,40 @@ async def test_async_update_data_auth_error_raises_update_failed(
 
 
 async def test_async_update_data_api_error_raises_update_failed(
-    hass: HomeAssistant, mock_api: AsyncMock
+    hass: HomeAssistant,
+    mock_api: AsyncMock,
+    mock_config_entry: MockConfigEntry,
 ):
     """Test API error during update raises UpdateFailed."""
     mock_api.get_wan_interfaces.side_effect = RutOSAPIError("network down")
-    coordinator = RutOSDataUpdateCoordinator(hass, mock_api)
+    mock_config_entry.add_to_hass(hass)
+    coordinator = RutOSDataUpdateCoordinator(hass, mock_config_entry, mock_api)
     coordinator.data = RutOSData()
 
     with pytest.raises(UpdateFailed, match="Error communicating"):
         await coordinator._async_update_data()
 
 
-async def test_update_interval_is_30s(hass: HomeAssistant, mock_api: AsyncMock):
+async def test_update_interval_is_30s(
+    hass: HomeAssistant,
+    mock_api: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+):
     """Test coordinator uses the configured scan interval."""
-    coordinator = RutOSDataUpdateCoordinator(hass, mock_api)
+    mock_config_entry.add_to_hass(hass)
+    coordinator = RutOSDataUpdateCoordinator(hass, mock_config_entry, mock_api)
     assert coordinator.update_interval == timedelta(seconds=DEFAULT_SCAN_INTERVAL)
 
 
 async def test_async_setup_initializes_data_when_none(
-    hass: HomeAssistant, mock_api: AsyncMock, mock_device_info: dict
+    hass: HomeAssistant,
+    mock_api: AsyncMock,
+    mock_device_info: dict,
+    mock_config_entry: MockConfigEntry,
 ):
     """Test _async_setup creates RutOSData when self.data is None."""
-    coordinator = RutOSDataUpdateCoordinator(hass, mock_api)
+    mock_config_entry.add_to_hass(hass)
+    coordinator = RutOSDataUpdateCoordinator(hass, mock_config_entry, mock_api)
     # Leave coordinator.data as None (the default before first refresh)
     assert coordinator.data is None
 
@@ -128,9 +157,11 @@ async def test_async_update_data_initializes_data_when_none(
     hass: HomeAssistant,
     mock_api: AsyncMock,
     mock_wan_interfaces: list[dict],
+    mock_config_entry: MockConfigEntry,
 ):
     """Test _async_update_data creates RutOSData when self.data is None."""
-    coordinator = RutOSDataUpdateCoordinator(hass, mock_api)
+    mock_config_entry.add_to_hass(hass)
+    coordinator = RutOSDataUpdateCoordinator(hass, mock_config_entry, mock_api)
     assert coordinator.data is None
 
     result = await coordinator._async_update_data()

--- a/tests/test_home_location.py
+++ b/tests/test_home_location.py
@@ -7,11 +7,10 @@ from unittest.mock import AsyncMock, call, patch
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+
 from custom_components.rutos.const import (
-    CONF_HOST,
-    CONF_PASSWORD,
     CONF_UPDATE_HOME_LOCATION,
-    CONF_USERNAME,
     DOMAIN,
 )
 from custom_components.rutos.coordinator import RutOSDataUpdateCoordinator
@@ -53,9 +52,7 @@ MOCK_GPS_POSITION = {
 }
 
 
-def _create_entry(
-    hass: HomeAssistant, options: dict | None = None
-) -> MockConfigEntry:
+def _create_entry(hass: HomeAssistant, options: dict | None = None) -> MockConfigEntry:
     """Create and add a mock config entry."""
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -10,11 +10,10 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
 from custom_components.rutos.api import RutOSAuthError
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+
 from custom_components.rutos.const import (
     ATTR_INTERFACES,
-    CONF_HOST,
-    CONF_PASSWORD,
-    CONF_USERNAME,
     DOMAIN,
     SERVICE_SET_FAILOVER_ORDER,
 )
@@ -84,9 +83,7 @@ async def test_async_setup_entry_success(
     """Test successful setup stores coordinator and forwards platforms."""
     entry = _create_entry(hass)
 
-    with patch(
-        "custom_components.rutos.RutOSAPI", return_value=mock_api_instance
-    ):
+    with patch("custom_components.rutos.RutOSAPI", return_value=mock_api_instance):
         result = await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
@@ -103,24 +100,18 @@ async def test_async_setup_entry_auth_failure(
     mock_api_instance.get_device_info.side_effect = RutOSAuthError("bad creds")
     entry = _create_entry(hass)
 
-    with patch(
-        "custom_components.rutos.RutOSAPI", return_value=mock_api_instance
-    ):
+    with patch("custom_components.rutos.RutOSAPI", return_value=mock_api_instance):
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
     assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_async_unload_entry(
-    hass: HomeAssistant, mock_api_instance: AsyncMock
-):
+async def test_async_unload_entry(hass: HomeAssistant, mock_api_instance: AsyncMock):
     """Test unloading an entry returns True."""
     entry = _create_entry(hass)
 
-    with patch(
-        "custom_components.rutos.RutOSAPI", return_value=mock_api_instance
-    ):
+    with patch("custom_components.rutos.RutOSAPI", return_value=mock_api_instance):
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
         result = await hass.config_entries.async_unload(entry.entry_id)
@@ -135,9 +126,7 @@ async def test_set_failover_order_service_registered(
     """Test the set_failover_order service exists after setup."""
     entry = _create_entry(hass)
 
-    with patch(
-        "custom_components.rutos.RutOSAPI", return_value=mock_api_instance
-    ):
+    with patch("custom_components.rutos.RutOSAPI", return_value=mock_api_instance):
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
@@ -150,9 +139,7 @@ async def test_set_failover_order_service_call(
     """Test service call invokes API and triggers refresh."""
     entry = _create_entry(hass)
 
-    with patch(
-        "custom_components.rutos.RutOSAPI", return_value=mock_api_instance
-    ):
+    with patch("custom_components.rutos.RutOSAPI", return_value=mock_api_instance):
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
@@ -174,9 +161,7 @@ async def test_register_services_idempotent(
 
     entry = _create_entry(hass)
 
-    with patch(
-        "custom_components.rutos.RutOSAPI", return_value=mock_api_instance
-    ):
+    with patch("custom_components.rutos.RutOSAPI", return_value=mock_api_instance):
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 
-
-
 from custom_components.rutos.const import DOMAIN
 from custom_components.rutos.coordinator import RutOSDataUpdateCoordinator
 from custom_components.rutos.sensor import (
@@ -33,9 +31,7 @@ class TestRutOSSensorEntity:
         expected = len(interfaces) * len(INTERFACE_SENSORS) + 1
         assert expected == 9  # 2 interfaces * 4 sensors + 1 active WAN
 
-    def test_status_sensor_value(
-        self, mock_coordinator: RutOSDataUpdateCoordinator
-    ):
+    def test_status_sensor_value(self, mock_coordinator: RutOSDataUpdateCoordinator):
         """Test status sensor returns up/down."""
         desc = INTERFACE_SENSORS[0]  # status
         sensor = RutOSSensorEntity(mock_coordinator, desc, "wan")
@@ -55,25 +51,19 @@ class TestRutOSSensorEntity:
         sensor_none = RutOSSensorEntity(mock_coordinator, desc, "mob1s1a1")
         assert sensor_none.native_value is None
 
-    def test_uptime_sensor_value(
-        self, mock_coordinator: RutOSDataUpdateCoordinator
-    ):
+    def test_uptime_sensor_value(self, mock_coordinator: RutOSDataUpdateCoordinator):
         """Test uptime sensor returns seconds."""
         desc = INTERFACE_SENSORS[3]  # uptime
         sensor = RutOSSensorEntity(mock_coordinator, desc, "wan")
         assert sensor.native_value == 3600
 
-    def test_unique_id_format(
-        self, mock_coordinator: RutOSDataUpdateCoordinator
-    ):
+    def test_unique_id_format(self, mock_coordinator: RutOSDataUpdateCoordinator):
         """Test unique_id follows {serial}_{interface}_{key} pattern."""
         desc = INTERFACE_SENSORS[0]
         sensor = RutOSSensorEntity(mock_coordinator, desc, "wan")
         assert sensor.unique_id == "1234567890_wan_status"
 
-    def test_device_info(
-        self, mock_coordinator: RutOSDataUpdateCoordinator
-    ):
+    def test_device_info(self, mock_coordinator: RutOSDataUpdateCoordinator):
         """Test device_info contains correct identifiers and manufacturer."""
         desc = INTERFACE_SENSORS[0]
         sensor = RutOSSensorEntity(mock_coordinator, desc, "wan")
@@ -91,9 +81,7 @@ class TestRutOSSensorEntity:
         sensor = RutOSSensorEntity(mock_coordinator, desc, "nonexistent")
         assert sensor.native_value is None
 
-    def test_proto_sensor_value(
-        self, mock_coordinator: RutOSDataUpdateCoordinator
-    ):
+    def test_proto_sensor_value(self, mock_coordinator: RutOSDataUpdateCoordinator):
         """Test protocol sensor returns the proto field."""
         desc = INTERFACE_SENSORS[2]  # proto
         sensor = RutOSSensorEntity(mock_coordinator, desc, "wan")
@@ -123,9 +111,7 @@ class TestRutOSActiveWANSensor:
         sensor = RutOSActiveWANSensor(mock_coordinator)
         assert sensor.native_value is None
 
-    def test_unique_id(
-        self, mock_coordinator: RutOSDataUpdateCoordinator
-    ):
+    def test_unique_id(self, mock_coordinator: RutOSDataUpdateCoordinator):
         """Test unique_id is {serial}_active_wan."""
         sensor = RutOSActiveWANSensor(mock_coordinator)
         assert sensor.unique_id == "1234567890_active_wan"
@@ -134,33 +120,25 @@ class TestRutOSActiveWANSensor:
 class TestRutOSGPSSensorEntity:
     """Tests for GPS sensor entities."""
 
-    def test_latitude_sensor_value(
-        self, mock_coordinator: RutOSDataUpdateCoordinator
-    ):
+    def test_latitude_sensor_value(self, mock_coordinator: RutOSDataUpdateCoordinator):
         """Test GPS latitude sensor returns latitude from GPS data."""
         desc = GPS_SENSORS[0]  # latitude
         sensor = RutOSGPSSensorEntity(mock_coordinator, desc)
         assert sensor.native_value == 37.7749
 
-    def test_longitude_sensor_value(
-        self, mock_coordinator: RutOSDataUpdateCoordinator
-    ):
+    def test_longitude_sensor_value(self, mock_coordinator: RutOSDataUpdateCoordinator):
         """Test GPS longitude sensor returns longitude from GPS data."""
         desc = GPS_SENSORS[1]  # longitude
         sensor = RutOSGPSSensorEntity(mock_coordinator, desc)
         assert sensor.native_value == -122.4194
 
-    def test_speed_sensor_value(
-        self, mock_coordinator: RutOSDataUpdateCoordinator
-    ):
+    def test_speed_sensor_value(self, mock_coordinator: RutOSDataUpdateCoordinator):
         """Test GPS speed sensor returns speed from GPS data."""
         desc = GPS_SENSORS[2]  # speed
         sensor = RutOSGPSSensorEntity(mock_coordinator, desc)
         assert sensor.native_value == 65.3
 
-    def test_altitude_sensor_value(
-        self, mock_coordinator: RutOSDataUpdateCoordinator
-    ):
+    def test_altitude_sensor_value(self, mock_coordinator: RutOSDataUpdateCoordinator):
         """Test GPS altitude sensor returns altitude from GPS data."""
         desc = GPS_SENSORS[3]  # altitude
         sensor = RutOSGPSSensorEntity(mock_coordinator, desc)
@@ -174,9 +152,7 @@ class TestRutOSGPSSensorEntity:
         sensor = RutOSGPSSensorEntity(mock_coordinator, desc)
         assert sensor.native_value == 12
 
-    def test_heading_sensor_value(
-        self, mock_coordinator: RutOSDataUpdateCoordinator
-    ):
+    def test_heading_sensor_value(self, mock_coordinator: RutOSDataUpdateCoordinator):
         """Test GPS heading sensor returns angle."""
         desc = GPS_SENSORS[5]  # heading
         sensor = RutOSGPSSensorEntity(mock_coordinator, desc)
@@ -190,26 +166,20 @@ class TestRutOSGPSSensorEntity:
         sensor = RutOSGPSSensorEntity(mock_coordinator, desc)
         assert sensor.native_value == "3D"
 
-    def test_no_gps_returns_none(
-        self, mock_coordinator: RutOSDataUpdateCoordinator
-    ):
+    def test_no_gps_returns_none(self, mock_coordinator: RutOSDataUpdateCoordinator):
         """Test GPS sensor returns None when no GPS data."""
         mock_coordinator.data.gps_position = None
         desc = GPS_SENSORS[0]
         sensor = RutOSGPSSensorEntity(mock_coordinator, desc)
         assert sensor.native_value is None
 
-    def test_accuracy_sensor_value(
-        self, mock_coordinator: RutOSDataUpdateCoordinator
-    ):
+    def test_accuracy_sensor_value(self, mock_coordinator: RutOSDataUpdateCoordinator):
         """Test GPS accuracy sensor returns accuracy from GPS data."""
         desc = GPS_SENSORS[7]  # accuracy
         sensor = RutOSGPSSensorEntity(mock_coordinator, desc)
         assert sensor.native_value == 5
 
-    def test_unique_id_format(
-        self, mock_coordinator: RutOSDataUpdateCoordinator
-    ):
+    def test_unique_id_format(self, mock_coordinator: RutOSDataUpdateCoordinator):
         """Test unique_id follows {serial}_{key} pattern."""
         desc = GPS_SENSORS[0]
         sensor = RutOSGPSSensorEntity(mock_coordinator, desc)
@@ -219,25 +189,19 @@ class TestRutOSGPSSensorEntity:
 class TestRutOSDataLimitSensor:
     """Tests for data limit sensor entities."""
 
-    def test_data_used_value(
-        self, mock_coordinator: RutOSDataUpdateCoordinator
-    ):
+    def test_data_used_value(self, mock_coordinator: RutOSDataUpdateCoordinator):
         """Test data used sensor returns bytes used."""
         desc = DATA_LIMIT_SENSORS[0]  # data_used
         sensor = RutOSDataLimitSensor(mock_coordinator, desc, "limit1")
         assert sensor.native_value == 2_500_000_000
 
-    def test_data_limit_value(
-        self, mock_coordinator: RutOSDataUpdateCoordinator
-    ):
+    def test_data_limit_value(self, mock_coordinator: RutOSDataUpdateCoordinator):
         """Test data limit sensor returns limit in bytes."""
         desc = DATA_LIMIT_SENSORS[1]  # data_limit
         sensor = RutOSDataLimitSensor(mock_coordinator, desc, "limit1")
         assert sensor.native_value == 5_000_000_000
 
-    def test_data_usage_percent(
-        self, mock_coordinator: RutOSDataUpdateCoordinator
-    ):
+    def test_data_usage_percent(self, mock_coordinator: RutOSDataUpdateCoordinator):
         """Test data usage percent is calculated correctly."""
         desc = DATA_LIMIT_SENSORS[2]  # data_usage_percent
         sensor = RutOSDataLimitSensor(mock_coordinator, desc, "limit1")
@@ -260,9 +224,7 @@ class TestRutOSDataLimitSensor:
         sensor = RutOSDataLimitSensor(mock_coordinator, desc, "nonexistent")
         assert sensor.native_value is None
 
-    def test_unique_id_format(
-        self, mock_coordinator: RutOSDataUpdateCoordinator
-    ):
+    def test_unique_id_format(self, mock_coordinator: RutOSDataUpdateCoordinator):
         """Test unique_id follows {serial}_{limit}_{key} pattern."""
         desc = DATA_LIMIT_SENSORS[0]
         sensor = RutOSDataLimitSensor(mock_coordinator, desc, "limit1")
@@ -272,49 +234,37 @@ class TestRutOSDataLimitSensor:
 class TestRutOSModemSignalSensor:
     """Tests for modem signal sensor entities."""
 
-    def test_rssi_value(
-        self, mock_coordinator: RutOSDataUpdateCoordinator
-    ):
+    def test_rssi_value(self, mock_coordinator: RutOSDataUpdateCoordinator):
         """Test RSSI sensor returns signal strength."""
         desc = MODEM_SIGNAL_SENSORS[0]  # rssi
         sensor = RutOSModemSignalSensor(mock_coordinator, desc, "modem1")
         assert sensor.native_value == -65
 
-    def test_rsrp_value(
-        self, mock_coordinator: RutOSDataUpdateCoordinator
-    ):
+    def test_rsrp_value(self, mock_coordinator: RutOSDataUpdateCoordinator):
         """Test RSRP sensor returns reference signal power."""
         desc = MODEM_SIGNAL_SENSORS[1]  # rsrp
         sensor = RutOSModemSignalSensor(mock_coordinator, desc, "modem1")
         assert sensor.native_value == -95
 
-    def test_rsrq_value(
-        self, mock_coordinator: RutOSDataUpdateCoordinator
-    ):
+    def test_rsrq_value(self, mock_coordinator: RutOSDataUpdateCoordinator):
         """Test RSRQ sensor returns reference signal quality."""
         desc = MODEM_SIGNAL_SENSORS[2]  # rsrq
         sensor = RutOSModemSignalSensor(mock_coordinator, desc, "modem1")
         assert sensor.native_value == -10
 
-    def test_sinr_value(
-        self, mock_coordinator: RutOSDataUpdateCoordinator
-    ):
+    def test_sinr_value(self, mock_coordinator: RutOSDataUpdateCoordinator):
         """Test SINR sensor returns signal-to-noise ratio."""
         desc = MODEM_SIGNAL_SENSORS[3]  # sinr
         sensor = RutOSModemSignalSensor(mock_coordinator, desc, "modem1")
         assert sensor.native_value == 12
 
-    def test_network_type_value(
-        self, mock_coordinator: RutOSDataUpdateCoordinator
-    ):
+    def test_network_type_value(self, mock_coordinator: RutOSDataUpdateCoordinator):
         """Test network type sensor returns LTE/5G etc."""
         desc = MODEM_SIGNAL_SENSORS[4]  # network_type
         sensor = RutOSModemSignalSensor(mock_coordinator, desc, "modem1")
         assert sensor.native_value == "LTE"
 
-    def test_band_value(
-        self, mock_coordinator: RutOSDataUpdateCoordinator
-    ):
+    def test_band_value(self, mock_coordinator: RutOSDataUpdateCoordinator):
         """Test band sensor returns band identifier."""
         desc = MODEM_SIGNAL_SENSORS[5]  # band
         sensor = RutOSModemSignalSensor(mock_coordinator, desc, "modem1")
@@ -328,9 +278,7 @@ class TestRutOSModemSignalSensor:
         sensor = RutOSModemSignalSensor(mock_coordinator, desc, "nonexistent")
         assert sensor.native_value is None
 
-    def test_unique_id_format(
-        self, mock_coordinator: RutOSDataUpdateCoordinator
-    ):
+    def test_unique_id_format(self, mock_coordinator: RutOSDataUpdateCoordinator):
         """Test unique_id follows {serial}_{modem}_{key} pattern."""
         desc = MODEM_SIGNAL_SENSORS[0]
         sensor = RutOSModemSignalSensor(mock_coordinator, desc, "modem1")
@@ -340,9 +288,7 @@ class TestRutOSModemSignalSensor:
 class TestRutOSModemStatusSensor:
     """Tests for modem status (operator) sensor entities."""
 
-    def test_operator_value(
-        self, mock_coordinator: RutOSDataUpdateCoordinator
-    ):
+    def test_operator_value(self, mock_coordinator: RutOSDataUpdateCoordinator):
         """Test operator sensor returns carrier name."""
         desc = MODEM_STATUS_SENSORS[0]  # operator
         sensor = RutOSModemStatusSensor(mock_coordinator, desc, "modem1")
@@ -356,9 +302,7 @@ class TestRutOSModemStatusSensor:
         sensor = RutOSModemStatusSensor(mock_coordinator, desc, "nonexistent")
         assert sensor.native_value is None
 
-    def test_unique_id_format(
-        self, mock_coordinator: RutOSDataUpdateCoordinator
-    ):
+    def test_unique_id_format(self, mock_coordinator: RutOSDataUpdateCoordinator):
         """Test unique_id follows {serial}_{modem}_{key} pattern."""
         desc = MODEM_STATUS_SENSORS[0]
         sensor = RutOSModemStatusSensor(mock_coordinator, desc, "modem1")

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -14,9 +14,7 @@ from custom_components.rutos.switch import RutOSInterfaceSwitch
 class TestRutOSInterfaceSwitch:
     """Tests for the WAN interface switch."""
 
-    def test_creates_per_interface(
-        self, mock_coordinator: RutOSDataUpdateCoordinator
-    ):
+    def test_creates_per_interface(self, mock_coordinator: RutOSDataUpdateCoordinator):
         """Test one switch is created per WAN interface."""
         switches = [
             RutOSInterfaceSwitch(mock_coordinator, iface["name"])
@@ -57,7 +55,9 @@ class TestRutOSInterfaceSwitch:
 
         await switch.async_turn_off()
 
-        mock_coordinator.api.set_interface_enabled.assert_awaited_once_with("mob1s1a1", False)
+        mock_coordinator.api.set_interface_enabled.assert_awaited_once_with(
+            "mob1s1a1", False
+        )
         mock_coordinator.async_request_refresh.assert_awaited_once()
 
     async def test_api_error_propagates(
@@ -78,9 +78,7 @@ class TestRutOSInterfaceSwitch:
         switch = RutOSInterfaceSwitch(mock_coordinator, "nonexistent")
         assert switch.is_on is False
 
-    def test_unique_id_format(
-        self, mock_coordinator: RutOSDataUpdateCoordinator
-    ):
+    def test_unique_id_format(self, mock_coordinator: RutOSDataUpdateCoordinator):
         """Test unique_id follows {serial}_{interface}_enabled pattern."""
         switch = RutOSInterfaceSwitch(mock_coordinator, "wan")
         assert switch.unique_id == "1234567890_wan_enabled"


### PR DESCRIPTION
## Summary
- Use `DeviceInfo` instead of plain dict in entity base class
- Import `CONF_HOST`/`CONF_USERNAME`/`CONF_PASSWORD` from `homeassistant.const` instead of redefining in `const.py`
- Pass `config_entry` to `DataUpdateCoordinator` (modern HA 2024.11+ pattern)
- Fix `async_get_options_flow` type hint (`ConfigEntry`, not `ConfigFlow`)
- Use typed `RutOSConfigEntry` in all platform `async_setup_entry` signatures
- Sync `strings.json` with `translations/en.json` (was missing options flow, GPS, data limit, modem, button, and roaming entities)
- Clean up services on last config entry unload
- Remove unused variables and imports
- Fix `asyncio.gather` return type with proper `cast`

## Test plan
- [x] All 150 existing tests pass
- [x] Ruff lint passes with zero errors
- [x] Ruff format passes with zero changes
- [ ] Verify integration loads correctly in HA
- [ ] Verify entities appear with correct names
- [ ] Verify service cleanup on unload (remove last entry, re-add)

🤖 Generated with [Claude Code](https://claude.com/claude-code)