### PR TITLE
Add SIM switch button and active SIM sensor

### DIFF
--- a/custom_components/rutos/api.py
+++ b/custom_components/rutos/api.py
@@ -279,6 +279,10 @@ class RutOSAPI:
         """Reboot a specific modem."""
         await self.post(f"/modems/{modem_id}/actions/reboot")
 
+    async def switch_sim(self, modem_id: str) -> None:
+        """Switch to the next SIM card on a specific modem."""
+        await self.post(f"/modems/{modem_id}/actions/switch_sim")
+
     async def get_modems(self) -> list[dict[str, Any]]:
         """Fetch list of available modems."""
         try:
@@ -345,6 +349,9 @@ class RutOSAPI:
                     "id": modem_id,
                     "operator": modem.get("operator"),
                     "roaming": "roaming" in operator_state.lower(),
+                    "active_sim": modem.get("active_sim"),
+                    "dual_sim": modem.get("dual_sim"),
+                    "sim_count": modem.get("sim_count"),
                 }
             )
         return modems

--- a/custom_components/rutos/button.py
+++ b/custom_components/rutos/button.py
@@ -25,6 +25,11 @@ async def async_setup_entry(
         RutOSModemRebootButton(coordinator, modem["id"])
         for modem in coordinator.data.modems
     )
+    entities.extend(
+        RutOSModemSwitchSimButton(coordinator, modem["id"])
+        for modem in coordinator.data.modem_status
+        if modem.get("dual_sim") or (modem.get("sim_count") or 0) >= 2
+    )
     async_add_entities(entities)
 
 
@@ -67,4 +72,28 @@ class RutOSModemRebootButton(RutOSEntity, ButtonEntity):
     async def async_press(self) -> None:
         """Handle the button press."""
         await self.coordinator.api.reboot_modem(self._modem_id)
+        await self.coordinator.async_request_refresh()
+
+
+class RutOSModemSwitchSimButton(RutOSEntity, ButtonEntity):
+    """Button to switch SIM card on a specific modem."""
+
+    _attr_translation_key = "modem_switch_sim"
+
+    def __init__(
+        self,
+        coordinator: RutOSDataUpdateCoordinator,
+        modem_id: str,
+    ) -> None:
+        """Initialize the button."""
+        super().__init__(coordinator)
+        self._modem_id = modem_id
+        self._attr_unique_id = (
+            f"{coordinator.data.device_info.get('serial', '')}_{modem_id}_switch_sim"
+        )
+        self._attr_translation_placeholders = {"modem": modem_id}
+
+    async def async_press(self) -> None:
+        """Handle the button press."""
+        await self.coordinator.api.switch_sim(self._modem_id)
         await self.coordinator.async_request_refresh()

--- a/custom_components/rutos/sensor.py
+++ b/custom_components/rutos/sensor.py
@@ -193,6 +193,14 @@ MODEM_STATUS_SENSORS: tuple[RutOSSensorEntityDescription, ...] = (
     ),
 )
 
+MODEM_DUAL_SIM_SENSORS: tuple[RutOSSensorEntityDescription, ...] = (
+    RutOSSensorEntityDescription(
+        key="active_sim",
+        translation_key="modem_active_sim",
+        value_fn=lambda m: m.get("active_sim"),
+    ),
+)
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -233,6 +241,11 @@ async def async_setup_entry(
             RutOSModemStatusSensor(coordinator, desc, modem_id)
             for desc in MODEM_STATUS_SENSORS
         )
+        if modem.get("dual_sim") or (modem.get("sim_count") or 0) >= 2:
+            entities.extend(
+                RutOSModemStatusSensor(coordinator, desc, modem_id)
+                for desc in MODEM_DUAL_SIM_SENSORS
+            )
     async_add_entities(entities)
 
 

--- a/custom_components/rutos/strings.json
+++ b/custom_components/rutos/strings.json
@@ -108,6 +108,9 @@
       },
       "modem_operator": {
         "name": "{modem} operator"
+      },
+      "modem_active_sim": {
+        "name": "{modem} active SIM"
       }
     },
     "button": {
@@ -116,6 +119,9 @@
       },
       "modem_reboot": {
         "name": "Reboot {modem}"
+      },
+      "modem_switch_sim": {
+        "name": "Switch SIM {modem}"
       }
     },
     "binary_sensor": {

--- a/custom_components/rutos/translations/en.json
+++ b/custom_components/rutos/translations/en.json
@@ -108,6 +108,9 @@
       },
       "modem_operator": {
         "name": "{modem} operator"
+      },
+      "modem_active_sim": {
+        "name": "{modem} active SIM"
       }
     },
     "button": {
@@ -116,6 +119,9 @@
       },
       "modem_reboot": {
         "name": "Reboot {modem}"
+      },
+      "modem_switch_sim": {
+        "name": "Switch SIM {modem}"
       }
     },
     "binary_sensor": {


### PR DESCRIPTION
## Summary
- Add `switch_sim(modem_id)` API method calling `POST /modems/{id}/actions/switch_sim`
- Extend `get_modem_status()` to extract `active_sim`, `dual_sim`, and `sim_count` from the existing `/modems/status` response
- Add `RutOSModemSwitchSimButton` — per-modem button to toggle SIM (dual-SIM modems only)
- Add `active_sim` sensor showing the currently active SIM number (dual-SIM modems only)

## Test plan
- [x] All 163 existing tests pass
- [x] ruff check clean
- [x] pyright clean (0 errors)
- [ ] Manual test on dual-SIM router: verify button triggers SIM switch and sensor updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)