### PR TITLE
Fix options flow test socket leak on reload

### DIFF
--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -216,23 +216,28 @@ async def test_options_flow_saves_failover_groups(
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
-    # Step 1: init
-    result = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
-    result = await hass.config_entries.options.async_configure(
-        result["flow_id"],
-        user_input={CONF_UPDATE_HOME_LOCATION: False},
-    )
+        # Step 1: init
+        result = await hass.config_entries.options.async_init(
+            mock_config_entry.entry_id
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={CONF_UPDATE_HOME_LOCATION: False},
+        )
 
-    # Step 2: failover_groups
-    result = await hass.config_entries.options.async_configure(
-        result["flow_id"],
-        user_input={
-            "mob1s1a1": "Cellular",
-            "mob1s2a1": "Cellular",
-            "wan1": "Starlink",
-            "wan2": "WiFi",
-        },
-    )
+        # Step 2: failover_groups — saving triggers a reload via the update
+        # listener, which re-instantiates RutOSAPI; keep the patch active and
+        # flush pending tasks so the reload uses the mock.
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                "mob1s1a1": "Cellular",
+                "mob1s2a1": "Cellular",
+                "wan1": "Starlink",
+                "wan2": "WiFi",
+            },
+        )
+        await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert mock_config_entry.options[CONF_UPDATE_HOME_LOCATION] is False


### PR DESCRIPTION
## Summary
- `test_options_flow_saves_failover_groups` was passing locally but erroring at teardown in the GitHub Actions runner with `HASocketBlockedError: A test tried to use socket.socket`.
- Saving options triggers `_async_options_updated` → `async_reload`, which re-instantiates `RutOSAPI`. The existing `with patch(...)` block had already exited by then, so the reload used the real API and opened a socket during the coordinator's first refresh.
- Fix: keep the `patch("custom_components.rutos.RutOSAPI", ...)` context active through both options-flow steps and call `await hass.async_block_till_done()` inside it so the reload uses the mocked API.

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_config_flow.py -v` — 11 passed
- [x] CI `Validate / Tests` job green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)