### PR TITLE
Fix Unknown modem signal sensors and mobile WAN IP (issue #17)

### DIFF
--- a/custom_components/rutos/api.py
+++ b/custom_components/rutos/api.py
@@ -14,6 +14,26 @@ from .const import API_PATH, SESSION_REFRESH_MARGIN
 _LOGGER = logging.getLogger(__name__)
 
 
+def _extract_ip(iface: dict[str, Any]) -> str | None:
+    """Extract a WAN IPv4 address in CIDR notation from an interface entry.
+
+    Different proto types report addresses differently: wired/DHCP interfaces
+    populate ``ipv4-address: [{address, mask}]``, while mobile interfaces on
+    some firmwares only populate ``ipaddrs: ["a.b.c.d/32"]``. CIDR is kept so
+    carrier-assigned subnet size is preserved.
+    """
+    ipv4_addrs = iface.get("ipv4-address") or []
+    if ipv4_addrs and isinstance(ipv4_addrs[0], dict):
+        addr = ipv4_addrs[0].get("address")
+        mask = ipv4_addrs[0].get("mask")
+        if addr:
+            return f"{addr}/{mask}" if mask is not None else addr
+    ipaddrs = iface.get("ipaddrs") or []
+    if ipaddrs and isinstance(ipaddrs[0], str) and ipaddrs[0]:
+        return ipaddrs[0]
+    return None
+
+
 class RutOSAPIError(Exception):
     """Base exception for RutOS API errors."""
 
@@ -207,8 +227,7 @@ class RutOSAPI:
             if iface.get("area_type") != "wan":
                 continue
 
-            ipv4_addrs = iface.get("ipv4-address", [])
-            ip_addr = ipv4_addrs[0].get("address") if ipv4_addrs else None
+            ip_addr = _extract_ip(iface)
 
             interfaces.append(
                 {
@@ -286,25 +305,12 @@ class RutOSAPI:
     async def get_modems(self) -> list[dict[str, Any]]:
         """Fetch list of available modems."""
         try:
-            data = await self.get("/modems/signal/status")
+            data = await self.get("/modems/status")
         except RutOSAPIError:
-            return []
-
-        if not isinstance(data, list):
-            return []
-
-        return [
-            {"id": modem.get("id", "")}
-            for modem in data
-            if isinstance(modem, dict) and modem.get("id")
-        ]
-
-    async def get_modem_signal(self) -> list[dict[str, Any]]:
-        """Fetch signal strength data for all modems."""
-        try:
-            data = await self.get("/modems/signal/status")
-        except RutOSAPIError:
-            return []
+            try:
+                data = await self.get("/modems/signal/status")
+            except RutOSAPIError:
+                return []
 
         if not isinstance(data, list):
             return []
@@ -313,17 +319,74 @@ class RutOSAPI:
         for modem in data:
             if not isinstance(modem, dict):
                 continue
-            modem_id = modem.get("id", "")
+            # /modems/status uses "id"; /modems/signal/status uses "modem"
+            modem_id = modem.get("id") or modem.get("modem")
+            if modem_id:
+                modems.append({"id": modem_id})
+        return modems
+
+    async def get_modem_signal(self) -> list[dict[str, Any]]:
+        """Fetch signal strength data for all modems.
+
+        Prefers flat top-level fields from /modems/status (rssi, rsrp, rsrq,
+        sinr, band, conntype). Falls back to /modems/signal/status where
+        metrics live in a nested 'signal' array of historical samples.
+        """
+        try:
+            status = await self.get("/modems/status")
+        except RutOSAPIError:
+            status = None
+
+        if isinstance(status, list) and status:
+            modems: list[dict[str, Any]] = []
+            for modem in status:
+                if not isinstance(modem, dict):
+                    continue
+                channel = None
+                ca_signal = modem.get("ca_signal") or []
+                if ca_signal and isinstance(ca_signal[0], dict):
+                    channel = ca_signal[0].get("frequency")
+                modems.append(
+                    {
+                        "id": modem.get("id") or modem.get("modem") or "",
+                        "rssi": modem.get("rssi"),
+                        "rsrp": modem.get("rsrp"),
+                        "rsrq": modem.get("rsrq"),
+                        "sinr": modem.get("sinr"),
+                        "network_type": modem.get("conntype") or modem.get("ntype"),
+                        "band": modem.get("band"),
+                        "channel_number": channel,
+                    }
+                )
+            return modems
+
+        try:
+            sig = await self.get("/modems/signal/status")
+        except RutOSAPIError:
+            return []
+        if not isinstance(sig, list):
+            return []
+
+        modems = []
+        for entry in sig:
+            if not isinstance(entry, dict):
+                continue
+            modem_id = entry.get("id") or entry.get("modem") or ""
+            samples = entry.get("signal")
+            if isinstance(samples, list) and samples and isinstance(samples[-1], dict):
+                src = samples[-1]
+            else:
+                src = entry
             modems.append(
                 {
                     "id": modem_id,
-                    "rssi": modem.get("rssi"),
-                    "rsrp": modem.get("rsrp"),
-                    "rsrq": modem.get("rsrq"),
-                    "sinr": modem.get("sinr"),
-                    "network_type": modem.get("network_type"),
-                    "band": modem.get("band"),
-                    "channel_number": modem.get("channel_number"),
+                    "rssi": src.get("rssi"),
+                    "rsrp": src.get("rsrp"),
+                    "rsrq": src.get("rsrq"),
+                    "sinr": src.get("sinr"),
+                    "network_type": src.get("network_type"),
+                    "band": src.get("band"),
+                    "channel_number": src.get("channel_number"),
                 }
             )
         return modems

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -411,7 +411,7 @@ class TestGetWanInterfaces:
             assert result[0]["metric"] < result[1]["metric"]
 
     async def test_get_wan_interfaces_extracts_ip(self, api_client):
-        """Test IP address is extracted from ipv4-address field."""
+        """Test IP address is extracted from ipv4-address field with CIDR."""
         interfaces = [
             {
                 "id": "wan",
@@ -431,10 +431,34 @@ class TestGetWanInterfaces:
 
             result = await api_client.get_wan_interfaces()
 
-            assert result[0]["ip_address"] == "192.168.1.100"
+            assert result[0]["ip_address"] == "192.168.1.100/24"
+
+    async def test_get_wan_interfaces_falls_back_to_ipaddrs(self, api_client):
+        """Mobile WANs populate ipaddrs[] (with CIDR) instead of ipv4-address."""
+        interfaces = [
+            {
+                "id": "mob1s2a1",
+                "area_type": "wan",
+                "is_up": True,
+                "proto": "wwan",
+                "uptime": 55093,
+                "metric": 2,
+                "ipv4-address": [],
+                "ipaddrs": ["10.153.142.57/32"],
+                "device": "wwan0",
+                "l3_device": "wwan0",
+            },
+        ]
+        with aioresponses() as m:
+            m.post(_url("/login"), payload=_login_success())
+            m.get(_url("/interfaces/status"), payload=_success(interfaces))
+
+            result = await api_client.get_wan_interfaces()
+
+            assert result[0]["ip_address"] == "10.153.142.57/32"
 
     async def test_get_wan_interfaces_no_ip(self, api_client):
-        """Test IP is None when no ipv4-address."""
+        """Test IP is None when neither ipv4-address nor ipaddrs is populated."""
         interfaces = [
             {
                 "id": "mob1s1a1",
@@ -851,34 +875,52 @@ class TestGetModems:
     """Tests for get_modems."""
 
     async def test_get_modems_success(self, api_client):
-        """Test parsing modem list from signal status."""
-        signal_data = [
-            {"id": "modem1", "rssi": -65},
-            {"id": "modem2", "rssi": -70},
+        """Test parsing modem list from /modems/status (top-level id)."""
+        status_data = [
+            {"id": "2-1", "operator": "Rogers"},
+            {"id": "3-1", "operator": "Bell"},
         ]
         with aioresponses() as m:
             m.post(_url("/login"), payload=_login_success())
-            m.get(_url("/modems/signal/status"), payload=_success(signal_data))
+            m.get(_url("/modems/status"), payload=_success(status_data))
 
             result = await api_client.get_modems()
 
             assert len(result) == 2
-            assert result[0]["id"] == "modem1"
-            assert result[1]["id"] == "modem2"
+            assert result[0]["id"] == "2-1"
+            assert result[1]["id"] == "3-1"
+
+    async def test_get_modems_falls_back_to_signal_status(self, api_client):
+        """If /modems/status errors, fall back to /modems/signal/status.
+
+        /modems/signal/status uses 'modem' as the id key instead of 'id'.
+        """
+        with aioresponses() as m:
+            m.post(_url("/login"), payload=_login_success())
+            m.get(_url("/modems/status"), payload=_error("unavailable"))
+            m.get(
+                _url("/modems/signal/status"),
+                payload=_success([{"modem": "2-1"}, {"modem": "3-1"}]),
+            )
+
+            result = await api_client.get_modems()
+
+            assert [r["id"] for r in result] == ["2-1", "3-1"]
 
     async def test_get_modems_empty(self, api_client):
         """Test returns empty list when no modems."""
         with aioresponses() as m:
             m.post(_url("/login"), payload=_login_success())
-            m.get(_url("/modems/signal/status"), payload=_success([]))
+            m.get(_url("/modems/status"), payload=_success([]))
 
             result = await api_client.get_modems()
             assert result == []
 
     async def test_get_modems_api_error(self, api_client):
-        """Test returns empty list on API error."""
+        """Test returns empty list when both endpoints fail."""
         with aioresponses() as m:
             m.post(_url("/login"), payload=_login_success())
+            m.get(_url("/modems/status"), payload=_error("Service unavailable"))
             m.get(
                 _url("/modems/signal/status"),
                 payload=_error("Service unavailable"),
@@ -891,44 +933,107 @@ class TestGetModems:
 class TestGetModemSignal:
     """Tests for get_modem_signal."""
 
-    async def test_get_modem_signal_success(self, api_client):
-        """Test parsing of modem signal response."""
-        signal_data = [
+    async def test_get_modem_signal_from_status(self, api_client):
+        """Primary path: /modems/status has flat signal fields."""
+        status_data = [
             {
-                "id": "modem1",
-                "rssi": -65,
-                "rsrp": -95,
-                "rsrq": -10,
-                "sinr": 12,
-                "network_type": "LTE",
-                "band": "B7",
-                "channel_number": 3100,
+                "id": "2-1",
+                "rssi": -73,
+                "rsrp": -98,
+                "rsrq": -8,
+                "sinr": 10,
+                "band": "LTE B12",
+                "conntype": "5G (NSA)",
+                "ntype": "5G-NSA",
+                "ca_signal": [{"frequency": 5060}],
             },
         ]
         with aioresponses() as m:
             m.post(_url("/login"), payload=_login_success())
+            m.get(_url("/modems/status"), payload=_success(status_data))
+
+            result = await api_client.get_modem_signal()
+
+            assert len(result) == 1
+            assert result[0]["id"] == "2-1"
+            assert result[0]["rssi"] == -73
+            assert result[0]["rsrp"] == -98
+            assert result[0]["rsrq"] == -8
+            assert result[0]["sinr"] == 10
+            assert result[0]["band"] == "LTE B12"
+            # conntype wins over ntype for human-readable network_type
+            assert result[0]["network_type"] == "5G (NSA)"
+            assert result[0]["channel_number"] == 5060
+
+    async def test_get_modem_signal_network_type_ntype_fallback(self, api_client):
+        """When conntype is absent, fall back to ntype."""
+        status_data = [{"id": "2-1", "rssi": -65, "ntype": "LTE-A"}]
+        with aioresponses() as m:
+            m.post(_url("/login"), payload=_login_success())
+            m.get(_url("/modems/status"), payload=_success(status_data))
+
+            result = await api_client.get_modem_signal()
+
+            assert result[0]["network_type"] == "LTE-A"
+
+    async def test_get_modem_signal_nested_signal_fallback(self, api_client):
+        """Fall back to /modems/signal/status nested 'signal' array when status fails."""
+        signal_data = [
+            {
+                "modem": "2-1",
+                "signal": [
+                    {
+                        "rssi": -80,
+                        "rsrp": -100,
+                        "rsrq": -12,
+                        "sinr": 5,
+                        "band": "LTE B12",
+                        "network_type": 24,
+                        "channel_number": 5060,
+                        "timestamp": "1776519700",
+                    },
+                    {
+                        "rssi": -72,
+                        "rsrp": -98,
+                        "rsrq": -8,
+                        "sinr": 9,
+                        "band": "LTE B12",
+                        "network_type": 24,
+                        "channel_number": 5060,
+                        "timestamp": "1776523359",
+                    },
+                ],
+            }
+        ]
+        with aioresponses() as m:
+            m.post(_url("/login"), payload=_login_success())
+            m.get(_url("/modems/status"), payload=_error("unavailable"))
             m.get(_url("/modems/signal/status"), payload=_success(signal_data))
 
             result = await api_client.get_modem_signal()
 
             assert len(result) == 1
-            assert result[0]["id"] == "modem1"
-            assert result[0]["rsrp"] == -95
-            assert result[0]["network_type"] == "LTE"
+            assert result[0]["id"] == "2-1"
+            # Latest sample (last element of signal[]) should win
+            assert result[0]["rssi"] == -72
+            assert result[0]["rsrp"] == -98
+            assert result[0]["channel_number"] == 5060
 
     async def test_get_modem_signal_empty(self, api_client):
-        """Test returns empty list when no modems."""
+        """Test returns empty list when no modems on either endpoint."""
         with aioresponses() as m:
             m.post(_url("/login"), payload=_login_success())
+            m.get(_url("/modems/status"), payload=_success([]))
             m.get(_url("/modems/signal/status"), payload=_success([]))
 
             result = await api_client.get_modem_signal()
             assert result == []
 
     async def test_get_modem_signal_api_error(self, api_client):
-        """Test returns empty list on API error."""
+        """Test returns empty list when both endpoints error."""
         with aioresponses() as m:
             m.post(_url("/login"), payload=_login_success())
+            m.get(_url("/modems/status"), payload=_error("Service unavailable"))
             m.get(
                 _url("/modems/signal/status"),
                 payload=_error("Service unavailable"),
@@ -938,9 +1043,10 @@ class TestGetModemSignal:
             assert result == []
 
     async def test_get_modem_signal_non_list(self, api_client):
-        """Test returns empty list for non-list response."""
+        """Test returns empty list when both endpoints return non-list."""
         with aioresponses() as m:
             m.post(_url("/login"), payload=_login_success())
+            m.get(_url("/modems/status"), payload=_success({"unexpected": True}))
             m.get(_url("/modems/signal/status"), payload=_success({"unexpected": True}))
 
             result = await api_client.get_modem_signal()


### PR DESCRIPTION
## Summary

- `get_modem_signal()` prefers flat top-level fields from `/modems/status`, with fallback to `/modems/signal/status` nested `signal[]` sample parsing
- `get_modems()` sources from `/modems/status` (top-level `id`), falling back to `/modems/signal/status` which uses `modem` as the id key
- `get_wan_interfaces()` preserves CIDR (`"10.153.142.57/32"`) and falls back to `ipaddrs[]` when `ipv4-address` is empty — fixes Unknown IP on mobile WANs

Evidence from the live router: https://github.com/crbn60/ha-rutos-integration/issues/17#issuecomment-4273925379

Closes #17.

## Test plan

- [x] `pytest tests/` — 167/167 pass
- [x] `ruff check` + `ruff format --check` clean on api.py
- [x] Live verification against RutOS 7.x router: `rssi=-74`, `rsrp=-100`, `rsrq=-9`, `sinr=9`, `network_type="5G (NSA)"`, `band="LTE B12"`, `channel_number=5060`; `mob1s2a1` IP resolves to `10.153.142.57/32`
- [ ] Verify on RUTX11 (reporter's device) once built

🤖 Generated with [Claude Code](https://claude.com/claude-code)