### PR TITLE
Drop modem id from labels on single-modem routers (#26)

### DIFF
--- a/custom_components/rutos/binary_sensor.py
+++ b/custom_components/rutos/binary_sensor.py
@@ -59,7 +59,9 @@ class RutOSModemRoamingSensor(RutOSEntity, BinarySensorEntity):
         self._attr_unique_id = (
             f"{coordinator.data.device_info.get('serial', '')}_{modem_id}_roaming"
         )
-        self._attr_translation_placeholders = {"modem": modem_id}
+        if len(coordinator.data.modems) > 1:
+            self._attr_translation_key = "modem_roaming_multi"
+            self._attr_translation_placeholders = {"modem": modem_id}
 
     @property
     def is_on(self) -> bool | None:

--- a/custom_components/rutos/button.py
+++ b/custom_components/rutos/button.py
@@ -67,7 +67,9 @@ class RutOSModemRebootButton(RutOSEntity, ButtonEntity):
         self._attr_unique_id = (
             f"{coordinator.data.device_info.get('serial', '')}_{modem_id}_reboot"
         )
-        self._attr_translation_placeholders = {"modem": modem_id}
+        if len(coordinator.data.modems) > 1:
+            self._attr_translation_key = "modem_reboot_multi"
+            self._attr_translation_placeholders = {"modem": modem_id}
 
     async def async_press(self) -> None:
         """Handle the button press."""
@@ -91,7 +93,9 @@ class RutOSModemSwitchSimButton(RutOSEntity, ButtonEntity):
         self._attr_unique_id = (
             f"{coordinator.data.device_info.get('serial', '')}_{modem_id}_switch_sim"
         )
-        self._attr_translation_placeholders = {"modem": modem_id}
+        if len(coordinator.data.modems) > 1:
+            self._attr_translation_key = "modem_switch_sim_multi"
+            self._attr_translation_placeholders = {"modem": modem_id}
 
     async def async_press(self) -> None:
         """Handle the button press."""

--- a/custom_components/rutos/sensor.py
+++ b/custom_components/rutos/sensor.py
@@ -354,7 +354,9 @@ class RutOSModemSignalSensor(RutOSEntity, SensorEntity):
         self.entity_description = description
         self._modem_id = modem_id
         self._attr_unique_id = f"{coordinator.data.device_info.get('serial', '')}_{modem_id}_{description.key}"
-        self._attr_translation_placeholders = {"modem": modem_id}
+        if len(coordinator.data.modems) > 1:
+            self._attr_translation_key = f"{description.translation_key}_multi"
+            self._attr_translation_placeholders = {"modem": modem_id}
 
     def _find_modem(self) -> dict[str, Any] | None:
         """Find modem data by id."""
@@ -388,7 +390,9 @@ class RutOSModemStatusSensor(RutOSEntity, SensorEntity):
         self.entity_description = description
         self._modem_id = modem_id
         self._attr_unique_id = f"{coordinator.data.device_info.get('serial', '')}_{modem_id}_{description.key}"
-        self._attr_translation_placeholders = {"modem": modem_id}
+        if len(coordinator.data.modems) > 1:
+            self._attr_translation_key = f"{description.translation_key}_multi"
+            self._attr_translation_placeholders = {"modem": modem_id}
 
     def _find_modem(self) -> dict[str, Any] | None:
         """Find modem data by id."""

--- a/custom_components/rutos/translations/en.json
+++ b/custom_components/rutos/translations/en.json
@@ -89,27 +89,51 @@
         "name": "{limit} data usage"
       },
       "modem_rssi": {
+        "name": "RSSI"
+      },
+      "modem_rssi_multi": {
         "name": "{modem} RSSI"
       },
       "modem_rsrp": {
+        "name": "RSRP"
+      },
+      "modem_rsrp_multi": {
         "name": "{modem} RSRP"
       },
       "modem_rsrq": {
+        "name": "RSRQ"
+      },
+      "modem_rsrq_multi": {
         "name": "{modem} RSRQ"
       },
       "modem_sinr": {
+        "name": "SINR"
+      },
+      "modem_sinr_multi": {
         "name": "{modem} SINR"
       },
       "modem_network_type": {
+        "name": "Network type"
+      },
+      "modem_network_type_multi": {
         "name": "{modem} network type"
       },
       "modem_band": {
+        "name": "Band"
+      },
+      "modem_band_multi": {
         "name": "{modem} band"
       },
       "modem_operator": {
+        "name": "Operator"
+      },
+      "modem_operator_multi": {
         "name": "{modem} operator"
       },
       "modem_active_sim": {
+        "name": "Active SIM"
+      },
+      "modem_active_sim_multi": {
         "name": "{modem} active SIM"
       }
     },
@@ -118,9 +142,15 @@
         "name": "Clear data usage"
       },
       "modem_reboot": {
+        "name": "Reboot modem"
+      },
+      "modem_reboot_multi": {
         "name": "Reboot {modem}"
       },
       "modem_switch_sim": {
+        "name": "Switch SIM"
+      },
+      "modem_switch_sim_multi": {
         "name": "Switch SIM {modem}"
       }
     },
@@ -129,6 +159,9 @@
         "name": "Internet connectivity"
       },
       "modem_roaming": {
+        "name": "Roaming"
+      },
+      "modem_roaming_multi": {
         "name": "{modem} roaming"
       }
     },

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -75,3 +75,20 @@ class TestRutOSModemRoamingSensor:
         """Test unique_id follows {serial}_{modem}_roaming pattern."""
         sensor = RutOSModemRoamingSensor(mock_coordinator, "modem1")
         assert sensor.unique_id == "1234567890_modem1_roaming"
+
+    def test_single_modem_no_placeholder(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Single modem: base translation key, no placeholder (issue #26)."""
+        sensor = RutOSModemRoamingSensor(mock_coordinator, "modem1")
+        assert sensor.translation_key == "modem_roaming"
+        assert not sensor.translation_placeholders
+
+    def test_multi_modem_uses_multi_key(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Multi modem: _multi translation key with {modem} placeholder."""
+        mock_coordinator.data.modems = [{"id": "2-1"}, {"id": "3-1"}]
+        sensor = RutOSModemRoamingSensor(mock_coordinator, "2-1")
+        assert sensor.translation_key == "modem_roaming_multi"
+        assert sensor.translation_placeholders == {"modem": "2-1"}

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -10,6 +10,7 @@ from custom_components.rutos.api import RutOSAPIError
 from custom_components.rutos.button import (
     RutOSClearDataUsageButton,
     RutOSModemRebootButton,
+    RutOSModemSwitchSimButton,
 )
 from custom_components.rutos.coordinator import RutOSDataUpdateCoordinator
 
@@ -62,9 +63,45 @@ class TestRutOSModemRebootButton:
         with pytest.raises(RutOSAPIError):
             await button.async_press()
 
-    def test_translation_placeholders(
+    def test_single_modem_no_placeholder(
         self, mock_coordinator: RutOSDataUpdateCoordinator
     ):
-        """Test translation placeholders include modem id."""
+        """Single modem: base translation key, no placeholder (issue #26)."""
         button = RutOSModemRebootButton(mock_coordinator, "modem1")
-        assert button.translation_placeholders == {"modem": "modem1"}
+        assert button.translation_key == "modem_reboot"
+        assert not button.translation_placeholders
+
+    def test_multi_modem_uses_multi_key(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Multi modem: _multi translation key with {modem} placeholder."""
+        mock_coordinator.data.modems = [{"id": "2-1"}, {"id": "3-1"}]
+        button = RutOSModemRebootButton(mock_coordinator, "2-1")
+        assert button.translation_key == "modem_reboot_multi"
+        assert button.translation_placeholders == {"modem": "2-1"}
+
+
+class TestRutOSModemSwitchSimButton:
+    """Tests for the modem switch SIM button (issue #26 naming)."""
+
+    def test_unique_id(self, mock_coordinator: RutOSDataUpdateCoordinator):
+        """Test unique_id is {serial}_{modem}_switch_sim."""
+        button = RutOSModemSwitchSimButton(mock_coordinator, "modem1")
+        assert button.unique_id == "1234567890_modem1_switch_sim"
+
+    def test_single_modem_no_placeholder(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Single modem: base translation key, no placeholder."""
+        button = RutOSModemSwitchSimButton(mock_coordinator, "modem1")
+        assert button.translation_key == "modem_switch_sim"
+        assert not button.translation_placeholders
+
+    def test_multi_modem_uses_multi_key(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Multi modem: _multi translation key with placeholder."""
+        mock_coordinator.data.modems = [{"id": "2-1"}, {"id": "3-1"}]
+        button = RutOSModemSwitchSimButton(mock_coordinator, "2-1")
+        assert button.translation_key == "modem_switch_sim_multi"
+        assert button.translation_placeholders == {"modem": "2-1"}

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -315,3 +315,46 @@ class TestRutOSModemStatusSensor:
         desc = MODEM_STATUS_SENSORS[0]
         sensor = RutOSModemStatusSensor(mock_coordinator, desc, "modem1")
         assert sensor.unique_id == "1234567890_modem1_operator"
+
+
+class TestModemSensorNaming:
+    """Tests for single-vs-multi modem label selection (issue #26)."""
+
+    def test_signal_single_modem_no_placeholder(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Single modem: use base translation key with no placeholder."""
+        desc = MODEM_SIGNAL_SENSORS[0]  # rssi
+        sensor = RutOSModemSignalSensor(mock_coordinator, desc, "modem1")
+        assert sensor.translation_key == "modem_rssi"
+        assert not sensor.translation_placeholders
+
+    def test_signal_multi_modem_uses_multi_key(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Multi modem: use _multi translation key with {modem} placeholder."""
+        mock_coordinator.data.modems = [{"id": "2-1"}, {"id": "3-1"}]
+        desc = MODEM_SIGNAL_SENSORS[0]
+        sensor = RutOSModemSignalSensor(mock_coordinator, desc, "2-1")
+        assert sensor.translation_key == "modem_rssi_multi"
+        assert sensor.translation_placeholders == {"modem": "2-1"}
+        assert sensor.unique_id == "1234567890_2-1_rssi"
+
+    def test_status_single_modem_no_placeholder(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Single modem: operator sensor uses base key with no placeholder."""
+        desc = MODEM_STATUS_SENSORS[0]  # operator
+        sensor = RutOSModemStatusSensor(mock_coordinator, desc, "modem1")
+        assert sensor.translation_key == "modem_operator"
+        assert not sensor.translation_placeholders
+
+    def test_status_multi_modem_uses_multi_key(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Multi modem: operator sensor uses _multi key with placeholder."""
+        mock_coordinator.data.modems = [{"id": "2-1"}, {"id": "3-1"}]
+        desc = MODEM_STATUS_SENSORS[0]
+        sensor = RutOSModemStatusSensor(mock_coordinator, desc, "2-1")
+        assert sensor.translation_key == "modem_operator_multi"
+        assert sensor.translation_placeholders == {"modem": "2-1"}


### PR DESCRIPTION
## Summary

- Add `_multi` sibling translation keys that preserve the `{modem}` placeholder; shorten the base keys to the single-modem label (e.g. `modem_rssi` → "RSSI", `modem_reboot` → "Reboot modem").
- In each modem entity's `__init__` (`RutOSModemSignalSensor`, `RutOSModemStatusSensor`, `RutOSModemRoamingSensor`, `RutOSModemRebootButton`, `RutOSModemSwitchSimButton`), only switch to the `_multi` key and set the `{modem}` placeholder when `len(coordinator.data.modems) > 1`.
- Unique IDs unchanged — they still embed the real API modem id (e.g. `2-1`), so existing entity registrations are preserved.

Fixes #26.

## Test plan

- [x] `.venv/bin/python -m pytest tests/` — 177 passed (10 new per-class tests for single/multi naming)
- [x] `.venv/bin/ruff check custom_components/rutos/` — clean
- [x] Reload integration against live router (single modem `2-1`) and confirm labels read `RSSI`, `Operator`, `Roaming`, `Reboot modem`, `Switch SIM` with no `2-1` prefix, while entity IDs still contain `_2_1_`
- [ ] Construct a two-modem coordinator in a sandbox and confirm labels render with `{modem}` substituted

🤖 Generated with [Claude Code](https://claude.com/claude-code)