### PR TITLE
Use router GUI name for WAN interface labels (#18)

### DIFF
--- a/custom_components/rutos/api.py
+++ b/custom_components/rutos/api.py
@@ -228,10 +228,12 @@ class RutOSAPI:
                 continue
 
             ip_addr = _extract_ip(iface)
+            iface_id = iface.get("id", "")
 
             interfaces.append(
                 {
-                    "name": iface.get("id", ""),
+                    "name": iface_id,
+                    "label": iface.get("name") or iface_id,
                     "enabled": iface.get("is_up", False),
                     "status": "up" if iface.get("is_up") else "down",
                     "ip_address": ip_addr,

--- a/custom_components/rutos/sensor.py
+++ b/custom_components/rutos/sensor.py
@@ -212,7 +212,7 @@ async def async_setup_entry(
     """Set up RutOS sensors based on a config entry."""
     coordinator: RutOSDataUpdateCoordinator = entry.runtime_data
     entities: list[SensorEntity] = [
-        RutOSSensorEntity(coordinator, description, iface["name"])
+        RutOSSensorEntity(coordinator, description, iface["name"], iface["label"])
         for iface in coordinator.data.wan_interfaces
         for description in INTERFACE_SENSORS
     ]
@@ -261,13 +261,14 @@ class RutOSSensorEntity(RutOSEntity, SensorEntity):
         coordinator: RutOSDataUpdateCoordinator,
         description: RutOSSensorEntityDescription,
         interface_name: str,
+        label: str | None = None,
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator)
         self.entity_description = description
         self._interface_name = interface_name
         self._attr_unique_id = f"{coordinator.data.device_info.get('serial', '')}_{interface_name}_{description.key}"
-        self._attr_translation_placeholders = {"interface": interface_name}
+        self._attr_translation_placeholders = {"interface": label or interface_name}
 
     @property
     def native_value(self) -> str | int | float | None:
@@ -433,5 +434,5 @@ class RutOSActiveWANSensor(RutOSEntity, SensorEntity):
         for iface in self.coordinator.data.wan_interfaces:
             if iface.get("status") == "up":
                 name = iface["name"]
-                return self._iface_labels.get(name, name)
+                return self._iface_labels.get(name) or iface.get("label") or name
         return None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,7 @@ def mock_wan_interfaces() -> list[dict]:
     return [
         {
             "name": "mob1s1a1",
+            "label": "mob1s1a1",
             "enabled": True,
             "status": "up",
             "ip_address": "10.0.0.1",
@@ -52,6 +53,7 @@ def mock_wan_interfaces() -> list[dict]:
         },
         {
             "name": "mob1s2a1",
+            "label": "mob1s2a1",
             "enabled": True,
             "status": "up",
             "ip_address": "10.0.0.2",
@@ -63,6 +65,7 @@ def mock_wan_interfaces() -> list[dict]:
         },
         {
             "name": "wan1",
+            "label": "wan1",
             "enabled": True,
             "status": "up",
             "ip_address": "192.168.1.100",
@@ -74,6 +77,7 @@ def mock_wan_interfaces() -> list[dict]:
         },
         {
             "name": "wan2",
+            "label": "wifi1",
             "enabled": True,
             "status": "up",
             "ip_address": "192.168.2.100",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -457,6 +457,37 @@ class TestGetWanInterfaces:
 
             assert result[0]["ip_address"] == "10.153.142.57/32"
 
+    async def test_get_wan_interfaces_uses_name_for_label(self, api_client):
+        """Issue #18: `label` comes from router `name` (GUI label), `name` stays UCI id."""
+        interfaces = [
+            {
+                "id": "wan2",
+                "name": "wifi1",
+                "area_type": "wan",
+                "is_up": True,
+                "proto": "dhcp",
+                "uptime": 10,
+                "metric": 1,
+            },
+            {
+                "id": "wan1",
+                "area_type": "wan",
+                "is_up": True,
+                "proto": "dhcp",
+                "uptime": 20,
+                "metric": 2,
+            },
+        ]
+        with aioresponses() as m:
+            m.post(_url("/login"), payload=_login_success())
+            m.get(_url("/interfaces/status"), payload=_success(interfaces))
+
+            result = await api_client.get_wan_interfaces()
+
+            by_name = {i["name"]: i for i in result}
+            assert by_name["wan2"]["label"] == "wifi1"
+            assert by_name["wan1"]["label"] == "wan1"
+
     async def test_get_wan_interfaces_no_ip(self, api_client):
         """Test IP is None when neither ipv4-address nor ipaddrs is populated."""
         interfaces = [

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -63,6 +63,23 @@ class TestRutOSSensorEntity:
         sensor = RutOSSensorEntity(mock_coordinator, desc, "wan1")
         assert sensor.unique_id == "1234567890_wan1_status"
 
+    def test_label_overrides_placeholder_keeps_unique_id(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Issue #18: router GUI label drives display; UCI id drives unique_id."""
+        desc = INTERFACE_SENSORS[0]
+        sensor = RutOSSensorEntity(mock_coordinator, desc, "wan2", "wifi1")
+        assert sensor.unique_id == "1234567890_wan2_status"
+        assert sensor.translation_placeholders == {"interface": "wifi1"}
+
+    def test_label_defaults_to_interface_name(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """When no label is passed, placeholder falls back to UCI id."""
+        desc = INTERFACE_SENSORS[0]
+        sensor = RutOSSensorEntity(mock_coordinator, desc, "wan1")
+        assert sensor.translation_placeholders == {"interface": "wan1"}
+
     def test_device_info(self, mock_coordinator: RutOSDataUpdateCoordinator):
         """Test device_info contains correct identifiers and manufacturer."""
         desc = INTERFACE_SENSORS[0]


### PR DESCRIPTION
## Summary

- WAN interface labels now come from the RutOS GUI rename (`name` field), falling back to the UCI id when unchanged
- Unique IDs stay keyed on the UCI id, so existing entity registrations survive the upgrade
- Fixes #18

See [issue comment](https://github.com/crbn60/ha-rutos-integration/issues/18#issuecomment-4274340766) for the raw router payload that exposed the bug.

## Test plan

- [x] `pytest tests/ -q` — 180/180 pass (3 new tests)
- [x] `ruff check` — clean
- [x] Against a live RUTM50 at `10.0.22.1`, `get_wan_interfaces()` returns `label: "wifi1"` for the renamed `wan2` interface; other entries keep `label == name`
- [ ] Reload the HA integration against the router and confirm the `wifi1` label surfaces in the UI (entity registry still references `wan2`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)