### PR TITLE
Fix switch state reflecting live link instead of config enabled (#20)

### DIFF
--- a/custom_components/rutos/api.py
+++ b/custom_components/rutos/api.py
@@ -223,18 +223,39 @@ class RutOSAPI:
         if not isinstance(data, list):
             return interfaces
 
+        # /interfaces/status reports live link state (is_up); the UCI "enabled"
+        # flag the router GUI and switch should track lives in /interfaces/config.
+        # Fall back to is_up if the config endpoint is unavailable.
+        config_by_id: dict[str, dict[str, Any]] = {}
+        try:
+            configs = await self.get("/interfaces/config")
+        except RutOSAPIError:
+            _LOGGER.debug("/interfaces/config unavailable; falling back to is_up")
+            configs = None
+        if isinstance(configs, list):
+            for cfg in configs:
+                if isinstance(cfg, dict) and cfg.get("area_type") == "wan":
+                    cfg_id = cfg.get("id")
+                    if isinstance(cfg_id, str):
+                        config_by_id[cfg_id] = cfg
+
         for iface in data:
             if iface.get("area_type") != "wan":
                 continue
 
             ip_addr = _extract_ip(iface)
             iface_id = iface.get("id", "")
+            cfg = config_by_id.get(iface_id)
+            if cfg is not None:
+                enabled = str(cfg.get("enabled", "0")) == "1"
+            else:
+                enabled = bool(iface.get("is_up", False))
 
             interfaces.append(
                 {
                     "name": iface_id,
                     "label": iface.get("name") or iface_id,
-                    "enabled": iface.get("is_up", False),
+                    "enabled": enabled,
                     "status": "up" if iface.get("is_up") else "down",
                     "ip_address": ip_addr,
                     "proto": iface.get("proto", ""),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -508,6 +508,87 @@ class TestGetWanInterfaces:
 
             assert result[0]["ip_address"] is None
 
+    async def test_get_wan_interfaces_enabled_from_config_not_is_up(self, api_client):
+        """Issue #20: `enabled` must come from /interfaces/config UCI flag, not is_up.
+
+        The bug scenario: interface is enabled in the router GUI but hasn't yet
+        come up (SIM negotiation, DHCP pending). /interfaces/status returns
+        is_up=null/false while /interfaces/config has enabled="1". The switch
+        must read the config flag so it doesn't flip back off after toggle.
+        """
+        status = [
+            {
+                "id": "mob1s1a1",
+                "area_type": "wan",
+                "is_up": None,
+                "proto": "wwan",
+                "uptime": 0,
+                "metric": 1,
+            },
+            {
+                "id": "wan3",
+                "area_type": "wan",
+                "is_up": False,
+                "proto": "static",
+                "uptime": 0,
+                "metric": 5,
+            },
+            {
+                "id": "mob1s2a1",
+                "area_type": "wan",
+                "is_up": True,
+                "proto": "wwan",
+                "uptime": 100,
+                "metric": 2,
+            },
+        ]
+        configs = [
+            {"id": "lan", "area_type": "lan", "enabled": "1"},
+            {"id": "mob1s1a1", "area_type": "wan", "enabled": "1"},
+            {"id": "wan3", "area_type": "wan", "enabled": "0"},
+            {"id": "mob1s2a1", "area_type": "wan", "enabled": "1"},
+        ]
+        with aioresponses() as m:
+            m.post(_url("/login"), payload=_login_success())
+            m.get(_url("/interfaces/status"), payload=_success(status))
+            m.get(_url("/interfaces/config"), payload=_success(configs))
+
+            result = await api_client.get_wan_interfaces()
+
+            by_name = {i["name"]: i for i in result}
+            # Enabled in config but link not up yet — the bug scenario.
+            assert by_name["mob1s1a1"]["enabled"] is True
+            assert by_name["mob1s1a1"]["status"] == "down"
+            # Disabled in config, link down — switch should be off.
+            assert by_name["wan3"]["enabled"] is False
+            assert by_name["wan3"]["status"] == "down"
+            # Enabled in config and link up.
+            assert by_name["mob1s2a1"]["enabled"] is True
+            assert by_name["mob1s2a1"]["status"] == "up"
+
+    async def test_get_wan_interfaces_falls_back_to_is_up_when_config_fails(
+        self, api_client
+    ):
+        """If /interfaces/config is unavailable, fall back to is_up for enabled."""
+        status = [
+            {
+                "id": "wan",
+                "area_type": "wan",
+                "is_up": True,
+                "proto": "dhcp",
+                "uptime": 100,
+                "metric": 1,
+            },
+        ]
+        with aioresponses() as m:
+            m.post(_url("/login"), payload=_login_success())
+            m.get(_url("/interfaces/status"), payload=_success(status))
+            m.get(_url("/interfaces/config"), status=500)
+
+            result = await api_client.get_wan_interfaces()
+
+            assert result[0]["enabled"] is True
+
 
 class TestGetInternetStatus:
     """Tests for get_internet_status."""


### PR DESCRIPTION
## Summary
- `get_wan_interfaces()` now merges `/interfaces/config` so `enabled` reflects the UCI toggle (router GUI state), not `is_up`
- Falls back to `is_up` if `/interfaces/config` is unavailable, preserving behavior on older firmware
- Fixes #20 — switches no longer flip back to off after toggling on

## Test plan
- [x] `pytest tests/` — 182 passed, including 2 new tests covering the bug scenario and the fallback
- [x] `ruff check` clean
- [x] Verified live against RUTX (firmware 07.21.x): `wan3` (UCI-disabled) reports `enabled=False`; four UCI-enabled interfaces report `enabled=True` regardless of link state; previously only the one `is_up=true` interface did
- [ ] End-to-end: toggle an offline WAN in HA, confirm switch stays ON while link is still negotiating

🤖 Generated with [Claude Code](https://claude.com/claude-code)