### PR TITLE
Add SMS notify platform (issue #31)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,7 @@ from the latest release on `main` by default. To test a different branch:
 
    ```bash
    rm -rf /config/custom_components/rutos
-   git clone https://github.com/tailgatelabs/ha-rutos-integration.git /tmp/rutos-repo
+   git clone https://github.com/crbn60/ha-rutos-integration.git /tmp/rutos-repo
    cp -r /tmp/rutos-repo/custom_components/rutos /config/custom_components/rutos
    rm -rf /tmp/rutos-repo
    ```
@@ -106,7 +106,7 @@ from the latest release on `main` by default. To test a different branch:
 
    ```bash
    cd /tmp  # use a temp clone to grab the branch
-   git clone -b my-feature https://github.com/tailgatelabs/ha-rutos-integration.git rutos-repo
+   git clone -b my-feature https://github.com/crbn60/ha-rutos-integration.git rutos-repo
    rm -rf /config/custom_components/rutos
    cp -r rutos-repo/custom_components/rutos /config/custom_components/rutos
    rm -rf rutos-repo
@@ -119,7 +119,7 @@ from the latest release on `main` by default. To test a different branch:
 1. Clone the repo on your development machine:
 
    ```bash
-   git clone https://github.com/tailgatelabs/ha-rutos-integration.git
+   git clone https://github.com/crbn60/ha-rutos-integration.git
    cd ha-rutos-integration
    git checkout dev  # or any branch/PR
    ```

--- a/custom_components/rutos/__init__.py
+++ b/custom_components/rutos/__init__.py
@@ -38,6 +38,7 @@ PLATFORMS: list[Platform] = [
     Platform.SWITCH,
     Platform.BUTTON,
     Platform.SELECT,
+    Platform.NOTIFY,
 ]
 
 type RutOSConfigEntry = ConfigEntry[RutOSDataUpdateCoordinator]

--- a/custom_components/rutos/api.py
+++ b/custom_components/rutos/api.py
@@ -325,6 +325,13 @@ class RutOSAPI:
         """Switch to the next SIM card on a specific modem."""
         await self.post(f"/modems/{modem_id}/actions/switch_sim")
 
+    async def send_sms(self, number: str, message: str, modem: str) -> dict[str, Any]:
+        """Send an SMS message via the specified modem."""
+        return await self.post(
+            "/messages/actions/send",
+            {"data": {"number": number, "message": message, "modem": modem}},
+        )
+
     async def get_modems(self) -> list[dict[str, Any]]:
         """Fetch list of available modems."""
         try:

--- a/custom_components/rutos/config_flow.py
+++ b/custom_components/rutos/config_flow.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any
 
 import voluptuous as vol
@@ -11,18 +12,23 @@ from homeassistant.config_entries import (
     ConfigEntry,
     ConfigFlow,
     ConfigFlowResult,
+    ConfigSubentryFlow,
     OptionsFlow,
+    SubentryFlowResult,
 )
-from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .api import RutOSAPI, RutOSAuthError, RutOSConnectionError
 from .const import (
     CONF_FAILOVER_GROUPS,
+    CONF_MODEM,
+    CONF_PHONE_NUMBER,
     CONF_UPDATE_HOME_LOCATION,
     DEFAULT_USERNAME,
     DOMAIN,
+    SUBENTRY_TYPE_RECIPIENT,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -37,6 +43,9 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
 
 MAX_FAILOVER_GROUPS = 5
 
+# Permissive E.164: leading +, then 6–15 digits.
+_PHONE_RE = re.compile(r"^\+\d{6,15}$")
+
 
 class RutOSConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for RutOS."""
@@ -50,6 +59,14 @@ class RutOSConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> RutOSOptionsFlowHandler:
         """Get the options flow for this handler."""
         return RutOSOptionsFlowHandler()
+
+    @classmethod
+    @callback
+    def async_get_supported_subentry_types(
+        cls, config_entry: ConfigEntry
+    ) -> dict[str, type[ConfigSubentryFlow]]:
+        """Subentry types supported by this integration."""
+        return {SUBENTRY_TYPE_RECIPIENT: RecipientSubentryFlowHandler}
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -153,12 +170,8 @@ class RutOSOptionsFlowHandler(OptionsFlow):
         # Fetch current failover members, excluding disabled interfaces
         coordinator = self.config_entry.runtime_data
         members = await coordinator.api.get_failover_members()
-        active_ifaces = {
-            iface["name"] for iface in coordinator.data.wan_interfaces
-        }
-        members = [
-            m for m in members if m.get("interface", "") in active_ifaces
-        ]
+        active_ifaces = {iface["name"] for iface in coordinator.data.wan_interfaces}
+        members = [m for m in members if m.get("interface", "") in active_ifaces]
 
         # Build reverse map: iface_id → existing label
         existing_groups: dict[str, list[str]] = self.config_entry.options.get(
@@ -181,5 +194,104 @@ class RutOSOptionsFlowHandler(OptionsFlow):
         return self.async_show_form(
             step_id="failover_groups",
             data_schema=vol.Schema(schema),
+            errors=errors,
+        )
+
+
+class RecipientSubentryFlowHandler(ConfigSubentryFlow):
+    """Handle subentries that represent SMS recipients."""
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> SubentryFlowResult:
+        """Add a new SMS recipient."""
+        return await self._async_handle_form(user_input)
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> SubentryFlowResult:
+        """Edit an existing SMS recipient."""
+        subentry = self._get_reconfigure_subentry()
+        return await self._async_handle_form(user_input, defaults=dict(subentry.data))
+
+    async def _async_handle_form(
+        self,
+        user_input: dict[str, Any] | None,
+        defaults: dict[str, Any] | None = None,
+    ) -> SubentryFlowResult:
+        """Render and validate the recipient form for both create and edit."""
+        defaults = defaults or {}
+        reconfigure = self.source == "reconfigure"
+        step_id = "reconfigure" if reconfigure else "user"
+
+        parent_entry = self._get_entry()
+        coordinator = parent_entry.runtime_data
+        modem_ids = [
+            m["id"]
+            for m in getattr(coordinator.data, "modems", [])
+            if isinstance(m, dict) and m.get("id")
+        ]
+
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            name = str(user_input.get(CONF_NAME, "")).strip()
+            phone = str(user_input.get(CONF_PHONE_NUMBER, "")).strip()
+            modem = str(user_input.get(CONF_MODEM, "")).strip() or None
+
+            if not name:
+                errors[CONF_NAME] = "required"
+            if not _PHONE_RE.match(phone):
+                errors[CONF_PHONE_NUMBER] = "invalid_phone"
+            if modem and modem_ids and modem not in modem_ids:
+                errors[CONF_MODEM] = "unknown_modem"
+            if not modem and len(modem_ids) > 1:
+                errors[CONF_MODEM] = "modem_required"
+
+            if not errors:
+                data: dict[str, Any] = {
+                    CONF_NAME: name,
+                    CONF_PHONE_NUMBER: phone,
+                }
+                if modem:
+                    data[CONF_MODEM] = modem
+                if reconfigure:
+                    return self.async_update_and_abort(
+                        parent_entry,
+                        self._get_reconfigure_subentry(),
+                        title=name,
+                        data=data,
+                    )
+                return self.async_create_entry(title=name, data=data)
+
+        # Pre-fill defaults: prefer user_input on validation errors, then existing data.
+        prefill = {**defaults, **(user_input or {})}
+
+        schema_dict: dict[Any, Any] = {
+            vol.Required(CONF_NAME, default=prefill.get(CONF_NAME, "")): str,
+            vol.Required(
+                CONF_PHONE_NUMBER, default=prefill.get(CONF_PHONE_NUMBER, "")
+            ): str,
+        }
+        if len(modem_ids) > 1:
+            schema_dict[
+                vol.Required(
+                    CONF_MODEM,
+                    default=prefill.get(CONF_MODEM, modem_ids[0]),
+                )
+            ] = vol.In(modem_ids)
+        elif modem_ids:
+            # Single modem: optional override, defaulted but free-text so users
+            # can clear it if they later add a modem.
+            schema_dict[
+                vol.Optional(
+                    CONF_MODEM,
+                    default=prefill.get(CONF_MODEM, modem_ids[0]),
+                )
+            ] = str
+
+        return self.async_show_form(
+            step_id=step_id,
+            data_schema=vol.Schema(schema_dict),
             errors=errors,
         )

--- a/custom_components/rutos/const.py
+++ b/custom_components/rutos/const.py
@@ -14,3 +14,7 @@ ATTR_INTERFACES = "interfaces"
 
 CONF_UPDATE_HOME_LOCATION = "update_home_location"
 CONF_FAILOVER_GROUPS = "failover_groups"
+
+SUBENTRY_TYPE_RECIPIENT = "recipient"
+CONF_PHONE_NUMBER = "phone_number"
+CONF_MODEM = "modem"

--- a/custom_components/rutos/notify.py
+++ b/custom_components/rutos/notify.py
@@ -1,0 +1,84 @@
+"""Notify platform for sending SMS via a RutOS router."""
+
+from __future__ import annotations
+
+from homeassistant.components.notify import NotifyEntity, NotifyEntityFeature
+from homeassistant.config_entries import ConfigSubentry
+from homeassistant.const import CONF_NAME
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import RutOSConfigEntry
+from .api import RutOSAPIError
+from .const import CONF_MODEM, CONF_PHONE_NUMBER, SUBENTRY_TYPE_RECIPIENT
+from .coordinator import RutOSDataUpdateCoordinator
+from .entity import RutOSEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: RutOSConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up one notify entity per recipient subentry."""
+    coordinator = entry.runtime_data
+    for subentry_id, subentry in entry.subentries.items():
+        if subentry.subentry_type != SUBENTRY_TYPE_RECIPIENT:
+            continue
+        async_add_entities(
+            [RutosSmsNotifyEntity(coordinator, subentry)],
+            config_subentry_id=subentry_id,
+        )
+
+
+class RutosSmsNotifyEntity(RutOSEntity, NotifyEntity):
+    """Notify entity that sends SMS to a configured recipient."""
+
+    _attr_supported_features = NotifyEntityFeature.TITLE
+
+    def __init__(
+        self,
+        coordinator: RutOSDataUpdateCoordinator,
+        subentry: ConfigSubentry,
+    ) -> None:
+        """Initialize from the recipient subentry."""
+        super().__init__(coordinator)
+        self._subentry = subentry
+        recipient_name = str(subentry.data.get(CONF_NAME, "Recipient"))
+        self._attr_name = f"SMS {recipient_name}"
+        serial = coordinator.data.device_info.get("serial", "")
+        self._attr_unique_id = f"{serial}_sms_{subentry.subentry_id}"
+
+    def _resolve_modem(self) -> str:
+        """Return the modem id to send through, or raise HomeAssistantError."""
+        configured = self._subentry.data.get(CONF_MODEM)
+        if configured:
+            return str(configured)
+        modem_ids = [
+            m["id"]
+            for m in self.coordinator.data.modems
+            if isinstance(m, dict) and m.get("id")
+        ]
+        if len(modem_ids) == 1:
+            return modem_ids[0]
+        if not modem_ids:
+            raise HomeAssistantError(
+                "No modem available on the router to send SMS through"
+            )
+        raise HomeAssistantError(
+            "Router has multiple modems; edit this recipient and pick one "
+            f"({', '.join(modem_ids)})"
+        )
+
+    async def async_send_message(self, message: str, title: str | None = None) -> None:
+        """Send an SMS to the configured phone number."""
+        number = str(self._subentry.data.get(CONF_PHONE_NUMBER, "")).strip()
+        if not number:
+            raise HomeAssistantError("Recipient has no phone number configured")
+        body = f"{title}: {message}" if title else message
+        modem = self._resolve_modem()
+        try:
+            await self.coordinator.api.send_sms(number, body, modem)
+        except RutOSAPIError as err:
+            raise HomeAssistantError(f"Failed to send SMS: {err}") from err

--- a/custom_components/rutos/translations/en.json
+++ b/custom_components/rutos/translations/en.json
@@ -20,6 +20,53 @@
       "already_configured": "This device is already configured."
     }
   },
+  "config_subentries": {
+    "recipient": {
+      "initiate_flow": {
+        "user": "Add SMS recipient",
+        "reconfigure": "Edit SMS recipient"
+      },
+      "entry_type": "SMS recipient",
+      "step": {
+        "user": {
+          "title": "Add SMS recipient",
+          "description": "A notify entity will be created for this recipient. Use it from automations via 'Notifications: Send a notification'.",
+          "data": {
+            "name": "Name",
+            "phone_number": "Phone number",
+            "modem": "Modem"
+          },
+          "data_description": {
+            "name": "Display name (used as part of the notify entity name).",
+            "phone_number": "Recipient in full E.164 format, e.g. +15551234567.",
+            "modem": "Which modem to send through. Required when the router has more than one modem."
+          }
+        },
+        "reconfigure": {
+          "title": "Edit SMS recipient",
+          "data": {
+            "name": "Name",
+            "phone_number": "Phone number",
+            "modem": "Modem"
+          },
+          "data_description": {
+            "name": "Display name (used as part of the notify entity name).",
+            "phone_number": "Recipient in full E.164 format, e.g. +15551234567.",
+            "modem": "Which modem to send through. Required when the router has more than one modem."
+          }
+        }
+      },
+      "error": {
+        "required": "This field is required.",
+        "invalid_phone": "Phone number must be in full E.164 format (e.g. +15551234567).",
+        "unknown_modem": "That modem id is not present on this router.",
+        "modem_required": "This router has multiple modems; please pick one."
+      },
+      "abort": {
+        "reconfigure_successful": "Recipient updated."
+      }
+    }
+  },
   "options": {
     "step": {
       "init": {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -14,8 +14,11 @@ from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 
 from custom_components.rutos.const import (
     CONF_FAILOVER_GROUPS,
+    CONF_MODEM,
+    CONF_PHONE_NUMBER,
     CONF_UPDATE_HOME_LOCATION,
     DOMAIN,
+    SUBENTRY_TYPE_RECIPIENT,
 )
 
 
@@ -277,3 +280,144 @@ async def test_options_flow_too_few_groups_error(
 
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "too_few_groups"}
+
+
+# ---------------------------------------------------------------------------
+# Recipient subentry flow tests
+# ---------------------------------------------------------------------------
+
+
+async def _setup_entry(hass, mock_config_entry, mock_api):
+    """Set up the config entry with the mocked API for subentry flow tests."""
+    mock_config_entry.add_to_hass(hass)
+    with patch("custom_components.rutos.RutOSAPI", return_value=mock_api):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+
+async def test_recipient_subentry_creates(hass, mock_config_entry, mock_api):
+    """Submitting valid input creates a recipient subentry on the parent entry."""
+    await _setup_entry(hass, mock_config_entry, mock_api)
+
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, SUBENTRY_TYPE_RECIPIENT),
+        context={"source": "user"},
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        {
+            "name": "Alice",
+            CONF_PHONE_NUMBER: "+15551234567",
+            CONF_MODEM: "modem1",
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Alice"
+
+    subentries = list(mock_config_entry.subentries.values())
+    assert len(subentries) == 1
+    assert subentries[0].data == {
+        "name": "Alice",
+        CONF_PHONE_NUMBER: "+15551234567",
+        CONF_MODEM: "modem1",
+    }
+
+
+async def test_recipient_subentry_invalid_phone(hass, mock_config_entry, mock_api):
+    """Bad phone format returns an inline error and no subentry is created."""
+    await _setup_entry(hass, mock_config_entry, mock_api)
+
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, SUBENTRY_TYPE_RECIPIENT),
+        context={"source": "user"},
+    )
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        {"name": "Alice", CONF_PHONE_NUMBER: "555-1234"},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {CONF_PHONE_NUMBER: "invalid_phone"}
+    assert not mock_config_entry.subentries
+
+
+async def test_recipient_subentry_multimodem_requires_choice(
+    hass, mock_config_entry, mock_api
+):
+    """When the router has >1 modem, modem must be picked."""
+    mock_api.get_modems.return_value = [{"id": "modem1"}, {"id": "modem2"}]
+    await _setup_entry(hass, mock_config_entry, mock_api)
+
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, SUBENTRY_TYPE_RECIPIENT),
+        context={"source": "user"},
+    )
+    # The form should expose modem as a vol.In, so submitting just name+phone
+    # raises a vol.Invalid which surfaces as a generic schema error. Submit
+    # with a valid modem on retry to confirm success.
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        {
+            "name": "Bob",
+            CONF_PHONE_NUMBER: "+15559998888",
+            CONF_MODEM: "modem2",
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert list(mock_config_entry.subentries.values())[0].data[CONF_MODEM] == "modem2"
+
+
+async def test_recipient_subentry_reconfigure(hass, mock_config_entry, mock_api):
+    """Reconfigure flow updates an existing recipient in place."""
+    from homeassistant.config_entries import ConfigSubentryData
+
+    mock_config_entry = type(mock_config_entry)(
+        domain=mock_config_entry.domain,
+        title=mock_config_entry.title,
+        data=dict(mock_config_entry.data),
+        unique_id=mock_config_entry.unique_id,
+        subentries_data=[
+            ConfigSubentryData(
+                data={
+                    "name": "Alice",
+                    CONF_PHONE_NUMBER: "+15551234567",
+                    CONF_MODEM: "modem1",
+                },
+                subentry_type=SUBENTRY_TYPE_RECIPIENT,
+                title="Alice",
+                unique_id=None,
+            ),
+        ],
+    )
+    await _setup_entry(hass, mock_config_entry, mock_api)
+    subentry_id = next(iter(mock_config_entry.subentries))
+
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, SUBENTRY_TYPE_RECIPIENT),
+        context={"source": "reconfigure", "subentry_id": subentry_id},
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        {
+            "name": "Alice (work)",
+            CONF_PHONE_NUMBER: "+15557776666",
+            CONF_MODEM: "modem1",
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    updated = mock_config_entry.subentries[subentry_id]
+    assert updated.data[CONF_PHONE_NUMBER] == "+15557776666"
+    assert updated.title == "Alice (work)"

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -1,0 +1,139 @@
+"""Tests for the RutOS notify platform (SMS)."""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+from unittest.mock import AsyncMock
+
+import pytest
+
+from homeassistant.config_entries import ConfigSubentry
+from homeassistant.exceptions import HomeAssistantError
+
+from custom_components.rutos.api import RutOSAPIError
+from custom_components.rutos.const import (
+    CONF_MODEM,
+    CONF_PHONE_NUMBER,
+    SUBENTRY_TYPE_RECIPIENT,
+)
+from custom_components.rutos.coordinator import RutOSDataUpdateCoordinator
+from custom_components.rutos.notify import RutosSmsNotifyEntity
+
+
+def _make_subentry(
+    *,
+    name: str = "Alice",
+    phone: str = "+15551234567",
+    modem: str | None = None,
+    subentry_id: str = "sub-alice",
+) -> ConfigSubentry:
+    """Build a recipient ConfigSubentry for tests."""
+    data: dict = {"name": name, CONF_PHONE_NUMBER: phone}
+    if modem:
+        data[CONF_MODEM] = modem
+    return ConfigSubentry(
+        data=MappingProxyType(data),
+        subentry_type=SUBENTRY_TYPE_RECIPIENT,
+        title=name,
+        unique_id=None,
+        subentry_id=subentry_id,
+    )
+
+
+class TestRutosSmsNotifyEntity:
+    """Tests for the SMS notify entity."""
+
+    def test_unique_id_includes_subentry_id(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """unique_id is {serial}_sms_{subentry_id}."""
+        entity = RutosSmsNotifyEntity(mock_coordinator, _make_subentry())
+        assert entity.unique_id == "1234567890_sms_sub-alice"
+
+    def test_name_uses_recipient(self, mock_coordinator: RutOSDataUpdateCoordinator):
+        """Entity name is 'SMS <recipient>'."""
+        entity = RutosSmsNotifyEntity(mock_coordinator, _make_subentry(name="Bob"))
+        assert entity.name == "SMS Bob"
+
+    async def test_send_uses_explicit_modem(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Modem stored on the subentry is passed to api.send_sms."""
+        entity = RutosSmsNotifyEntity(
+            mock_coordinator,
+            _make_subentry(phone="+15550001111", modem="modem9"),
+        )
+
+        await entity.async_send_message("hello world")
+
+        mock_coordinator.api.send_sms.assert_awaited_once_with(
+            "+15550001111", "hello world", "modem9"
+        )
+
+    async def test_send_auto_picks_single_modem(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """No modem on subentry, router has one modem -> auto-pick it."""
+        # mock_modems fixture defaults to [{"id": "modem1"}].
+        entity = RutosSmsNotifyEntity(mock_coordinator, _make_subentry())
+
+        await entity.async_send_message("ping")
+
+        mock_coordinator.api.send_sms.assert_awaited_once_with(
+            "+15551234567", "ping", "modem1"
+        )
+
+    async def test_send_title_prefixed(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Title is prepended to the message body since SMS has no title field."""
+        entity = RutosSmsNotifyEntity(mock_coordinator, _make_subentry())
+
+        await entity.async_send_message("door open", title="ALERT")
+
+        mock_coordinator.api.send_sms.assert_awaited_once_with(
+            "+15551234567", "ALERT: door open", "modem1"
+        )
+
+    async def test_send_ambiguous_modem_raises(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Multiple modems with no explicit choice -> HomeAssistantError."""
+        mock_coordinator.data.modems = [{"id": "modemA"}, {"id": "modemB"}]
+        entity = RutosSmsNotifyEntity(mock_coordinator, _make_subentry())
+
+        with pytest.raises(HomeAssistantError, match="multiple modems"):
+            await entity.async_send_message("hi")
+        mock_coordinator.api.send_sms.assert_not_called()
+
+    async def test_send_no_modem_raises(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Router reports no modems -> HomeAssistantError."""
+        mock_coordinator.data.modems = []
+        entity = RutosSmsNotifyEntity(mock_coordinator, _make_subentry())
+
+        with pytest.raises(HomeAssistantError, match="No modem available"):
+            await entity.async_send_message("hi")
+
+    async def test_send_api_error_wrapped(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """RutOSAPIError surfaces as HomeAssistantError."""
+        mock_coordinator.api.send_sms = AsyncMock(
+            side_effect=RutOSAPIError("invalid number")
+        )
+        entity = RutosSmsNotifyEntity(mock_coordinator, _make_subentry())
+
+        with pytest.raises(HomeAssistantError, match="Failed to send SMS"):
+            await entity.async_send_message("hi")
+
+    async def test_send_empty_phone_raises(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Subentry with no phone number is rejected before any API call."""
+        entity = RutosSmsNotifyEntity(mock_coordinator, _make_subentry(phone=""))
+
+        with pytest.raises(HomeAssistantError, match="no phone number"):
+            await entity.async_send_message("hi")
+        mock_coordinator.api.send_sms.assert_not_called()


### PR DESCRIPTION
## Summary
- Adds a notify entity per configured SMS recipient that sends through the router's cellular modem via `POST /messages/actions/send`
- Recipients are managed as config subentries on each RutOS device (name, phone number, optional modem). Each one becomes a `notify.<router>_sms_<recipient>` entity usable from any automation via "Send a notification"
- Picks the modem automatically when the router has only one; requires an explicit choice on multi-modem routers

Closes #31

## Files
- `api.py`: new `RutOSAPI.send_sms(number, message, modem)`
- `config_flow.py`: `RecipientSubentryFlowHandler` (create + reconfigure) wired up via `async_get_supported_subentry_types`
- `notify.py` (new): `RutosSmsNotifyEntity` with single-modem auto-pick and helpful errors
- `__init__.py`: registers `Platform.NOTIFY`; existing update listener already reloads on subentry change
- `const.py` + `translations/en.json`: new keys/strings
- Tests: 9 in `test_notify.py` + 4 subentry-flow tests added to `test_config_flow.py` (200 pass total)

## Test plan
- [x] Reload integration on a real router (no recipients yet) — no notify entities appear
- [x] Settings → Devices & Services → RutOS device → "Add SMS recipient" → enter Name/Phone (E.164) → entity `notify.<router>_sms_<name>` appears
- [x] Developer Tools → Actions → `notify.send_message` with that entity_id and a test message → SMS delivered
- [x] Add a second recipient; sending to one does not reach the other
- [x] Edit an existing recipient via "Reconfigure"; reload happens automatically and entity reflects new number
- [x] Delete a recipient subentry; the notify entity disappears
- [ ] Multi-modem router: a recipient saved without `modem` raises a clear `HomeAssistantError` in Logbook on send
- [x] Malformed phone number on the API side returns 422 → surfaces as `HomeAssistantError`