### PR TITLE
Add bands sensor for carrier aggregation (#34)

### DIFF
--- a/custom_components/rutos/api.py
+++ b/custom_components/rutos/api.py
@@ -34,6 +34,34 @@ def _extract_ip(iface: dict[str, Any]) -> str | None:
     return None
 
 
+def _normalize_carriers(ca_signal: Any) -> list[dict[str, Any]]:
+    """Normalize the /modems/status ``ca_signal`` array into a carriers list.
+
+    The Vuci API returns one entry per aggregated carrier (LTE CA and/or 5G
+    NSA/NR-CA). Each entry carries its own band/bandwidth/RSRP/RSRQ/SINR and a
+    ``primary`` flag identifying the PCell.
+    """
+    out: list[dict[str, Any]] = []
+    if not isinstance(ca_signal, list):
+        return out
+    for c in ca_signal:
+        if not isinstance(c, dict):
+            continue
+        out.append(
+            {
+                "band": c.get("band"),
+                "primary": bool(c.get("primary")),
+                "bandwidth": c.get("bandwidth"),
+                "rsrp": c.get("rsrp"),
+                "rsrq": c.get("rsrq"),
+                "sinr": c.get("sinr"),
+                "pcid": c.get("pcid"),
+                "frequency": c.get("frequency"),
+            }
+        )
+    return out
+
+
 class RutOSAPIError(Exception):
     """Base exception for RutOS API errors."""
 
@@ -372,10 +400,14 @@ class RutOSAPI:
             for modem in status:
                 if not isinstance(modem, dict):
                     continue
-                channel = None
-                ca_signal = modem.get("ca_signal") or []
-                if ca_signal and isinstance(ca_signal[0], dict):
-                    channel = ca_signal[0].get("frequency")
+                carriers = _normalize_carriers(modem.get("ca_signal"))
+                primary = next((c for c in carriers if c["primary"]), None)
+                if primary is not None:
+                    band = primary["band"]
+                    channel = primary["frequency"]
+                else:
+                    band = modem.get("band")
+                    channel = carriers[0]["frequency"] if carriers else None
                 modems.append(
                     {
                         "id": modem.get("id") or modem.get("modem") or "",
@@ -384,8 +416,9 @@ class RutOSAPI:
                         "rsrq": modem.get("rsrq"),
                         "sinr": modem.get("sinr"),
                         "network_type": modem.get("conntype") or modem.get("ntype"),
-                        "band": modem.get("band"),
+                        "band": band,
                         "channel_number": channel,
+                        "carriers": carriers,
                     }
                 )
             return modems
@@ -417,6 +450,7 @@ class RutOSAPI:
                     "network_type": src.get("network_type"),
                     "band": src.get("band"),
                     "channel_number": src.get("channel_number"),
+                    "carriers": [],
                 }
             )
         return modems

--- a/custom_components/rutos/sensor.py
+++ b/custom_components/rutos/sensor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
@@ -26,6 +27,67 @@ class RutOSSensorEntityDescription(SensorEntityDescription):
     """Describe a RutOS sensor entity."""
 
     value_fn: Callable[[dict[str, Any]], str | int | float | None]
+    attributes_fn: Callable[[dict[str, Any]], dict[str, Any]] | None = None
+
+
+_BAND_RE = re.compile(r"(?P<rat>LTE|5G)\s*[BN]?(?P<num>\d+)", re.IGNORECASE)
+
+
+def _bands_attributes(modem: dict[str, Any]) -> dict[str, Any]:
+    """Expose the raw carrier list and primary band on the bands sensor.
+
+    ``band`` on the modem dict is already sourced from the primary carrier by
+    ``RutOSAPI.get_modem_signal`` when ``ca_signal`` is present, so reuse it
+    instead of re-searching the carriers list.
+    """
+    carriers = modem.get("carriers") or []
+    return {
+        "carriers": carriers,
+        "primary_band": modem.get("band") if carriers else None,
+    }
+
+
+def _format_bands(carriers: list[dict[str, Any]], fallback: str | None) -> str | None:
+    """Render a carrier-aggregation list into a compact display string.
+
+    Example output: ``"LTE 7 (P), 2, 66 + 5G 78×2"``. Intra-band duplicates
+    (same RAT + band number, e.g. two N78 NR carriers) are collapsed with an
+    ``×N`` suffix. When no carriers are parseable, falls back to the primary
+    band string so the sensor still has a value on non-CA modems.
+    """
+    if not carriers:
+        return fallback
+    groups: dict[str, list[list[Any]]] = {"LTE": [], "5G": []}
+    seen: dict[tuple[str, str], int] = {}
+    for c in carriers:
+        m = _BAND_RE.search(str(c.get("band") or ""))
+        if not m:
+            continue
+        rat = m.group("rat").upper()
+        num = m.group("num")
+        key = (rat, num)
+        if key in seen:
+            entry = groups[rat][seen[key]]
+            entry[1] = entry[1] or bool(c.get("primary"))
+            entry[2] += 1
+        else:
+            seen[key] = len(groups[rat])
+            groups[rat].append([num, bool(c.get("primary")), 1])
+    parts: list[str] = []
+    for rat in ("LTE", "5G"):
+        bands = groups[rat]
+        if not bands:
+            continue
+        rendered: list[str] = []
+        for num, primary, count in bands:
+            s = str(num)
+            if primary:
+                s += " (P)"
+            if count > 1:
+                s += f"×{count}"
+            rendered.append(s)
+        parts.append(f"{rat} {', '.join(rendered)}")
+    return " + ".join(parts) if parts else fallback
 
 
 INTERFACE_SENSORS: tuple[RutOSSensorEntityDescription, ...] = (
@@ -184,6 +246,12 @@ MODEM_SIGNAL_SENSORS: tuple[RutOSSensorEntityDescription, ...] = (
         key="band",
         translation_key="modem_band",
         value_fn=lambda m: m.get("band"),
+    ),
+    RutOSSensorEntityDescription(
+        key="bands",
+        translation_key="modem_bands",
+        value_fn=lambda m: _format_bands(m.get("carriers") or [], m.get("band")),
+        attributes_fn=_bands_attributes,
     ),
 )
 
@@ -373,6 +441,16 @@ class RutOSModemSignalSensor(RutOSEntity, SensorEntity):
         if modem is None:
             return None
         return self.entity_description.value_fn(modem)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Return structured extras for sensors that opt into attributes."""
+        if self.entity_description.attributes_fn is None:
+            return None
+        modem = self._find_modem()
+        if modem is None:
+            return None
+        return self.entity_description.attributes_fn(modem)
 
 
 class RutOSModemStatusSensor(RutOSEntity, SensorEntity):

--- a/custom_components/rutos/strings.json
+++ b/custom_components/rutos/strings.json
@@ -106,6 +106,9 @@
       "modem_band": {
         "name": "{modem} band"
       },
+      "modem_bands": {
+        "name": "{modem} bands"
+      },
       "modem_operator": {
         "name": "{modem} operator"
       },

--- a/custom_components/rutos/translations/en.json
+++ b/custom_components/rutos/translations/en.json
@@ -171,6 +171,12 @@
       "modem_band_multi": {
         "name": "{modem} band"
       },
+      "modem_bands": {
+        "name": "Bands"
+      },
+      "modem_bands_multi": {
+        "name": "{modem} bands"
+      },
       "modem_operator": {
         "name": "Operator"
       },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -135,6 +135,81 @@ def mock_modem_signal() -> list[dict]:
             "network_type": "LTE",
             "band": "B7",
             "channel_number": 3100,
+            "carriers": [],
+        },
+    ]
+
+
+@pytest.fixture
+def mock_modem_signal_nsa_ca() -> list[dict]:
+    """Return mock modem signal data for a 5G-NSA 3CA LTE + 2x N78 NR configuration.
+
+    Shape mirrors the normalized output of ``RutOSAPI.get_modem_signal`` when the
+    router reports ``ca_signal`` entries. The top-level ``band`` is sourced from
+    the primary carrier (LTE B7), not the top-level NR anchor.
+    """
+    return [
+        {
+            "id": "modem1",
+            "rssi": -62,
+            "rsrp": -97,
+            "rsrq": -12,
+            "sinr": 11,
+            "network_type": "5G (NSA)",
+            "band": "LTE B7",
+            "channel_number": 2850,
+            "carriers": [
+                {
+                    "band": "LTE B7",
+                    "primary": True,
+                    "bandwidth": "20",
+                    "rsrp": -97,
+                    "rsrq": -12,
+                    "sinr": 11,
+                    "pcid": 82,
+                    "frequency": 2850,
+                },
+                {
+                    "band": "LTE B2",
+                    "primary": False,
+                    "bandwidth": "20",
+                    "rsrp": -93,
+                    "rsrq": -14,
+                    "sinr": 4,
+                    "pcid": 82,
+                    "frequency": 900,
+                },
+                {
+                    "band": "LTE B66",
+                    "primary": False,
+                    "bandwidth": "15",
+                    "rsrp": -103,
+                    "rsrq": -19,
+                    "sinr": -2,
+                    "pcid": 82,
+                    "frequency": 66811,
+                },
+                {
+                    "band": "5G N78",
+                    "primary": False,
+                    "bandwidth": "50",
+                    "rsrp": -113,
+                    "rsrq": -19,
+                    "sinr": -7,
+                    "pcid": 129,
+                    "frequency": 640608,
+                },
+                {
+                    "band": "5G N78",
+                    "primary": False,
+                    "bandwidth": "30",
+                    "rsrp": -113,
+                    "rsrq": -19,
+                    "sinr": -7,
+                    "pcid": 129,
+                    "frequency": 633984,
+                },
+            ],
         },
     ]
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1164,6 +1164,87 @@ class TestGetModemSignal:
             result = await api_client.get_modem_signal()
             assert result == []
 
+    async def test_get_modem_signal_carrier_aggregation(self, api_client):
+        """5G-NSA with aggregated LTE + NR carriers: primary PCell overrides top-level band."""
+        status_data = [
+            {
+                "id": "2-1",
+                "rssi": -62,
+                "band": "5G N78",
+                "conntype": "5G (NSA)",
+                "ca_signal": [
+                    {
+                        "band": "LTE B7",
+                        "primary": True,
+                        "bandwidth": "20",
+                        "rsrp": -97,
+                        "rsrq": -12,
+                        "sinr": 11,
+                        "pcid": 82,
+                        "frequency": 2850,
+                    },
+                    {
+                        "band": "5G N78",
+                        "primary": False,
+                        "bandwidth": "50",
+                        "rsrp": -113,
+                        "rsrq": -19,
+                        "sinr": -7,
+                        "pcid": 129,
+                        "frequency": 640608,
+                    },
+                ],
+            }
+        ]
+        with aioresponses() as m:
+            m.post(_url("/login"), payload=_login_success())
+            m.get(_url("/modems/status"), payload=_success(status_data))
+
+            result = await api_client.get_modem_signal()
+
+            assert len(result) == 1
+            # Primary carrier (LTE B7) overrides the misleading top-level "5G N78".
+            assert result[0]["band"] == "LTE B7"
+            assert result[0]["channel_number"] == 2850
+            assert len(result[0]["carriers"]) == 2
+            assert result[0]["carriers"][0]["band"] == "LTE B7"
+            assert result[0]["carriers"][0]["primary"] is True
+            assert result[0]["carriers"][1]["band"] == "5G N78"
+            assert result[0]["carriers"][1]["primary"] is False
+
+    async def test_get_modem_signal_carriers_empty_without_ca_signal(self, api_client):
+        """Modems with no ca_signal still get carriers=[] for attribute parity."""
+        status_data = [{"id": "2-1", "band": "LTE B12"}]
+        with aioresponses() as m:
+            m.post(_url("/login"), payload=_login_success())
+            m.get(_url("/modems/status"), payload=_success(status_data))
+
+            result = await api_client.get_modem_signal()
+            assert result[0]["carriers"] == []
+            assert result[0]["band"] == "LTE B12"
+
+    async def test_get_modem_signal_fallback_emits_empty_carriers(self, api_client):
+        """Fallback /modems/signal/status path has no ca_signal — carriers must be []."""
+        signal_data = [
+            {
+                "modem": "2-1",
+                "signal": [
+                    {
+                        "rssi": -72,
+                        "band": "LTE B12",
+                        "channel_number": 5060,
+                    }
+                ],
+            }
+        ]
+        with aioresponses() as m:
+            m.post(_url("/login"), payload=_login_success())
+            m.get(_url("/modems/status"), payload=_error("unavailable"))
+            m.get(_url("/modems/signal/status"), payload=_success(signal_data))
+
+            result = await api_client.get_modem_signal()
+            assert result[0]["carriers"] == []
+
 
 class TestGetModemStatus:
     """Tests for get_modem_status."""

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -17,7 +17,18 @@ from custom_components.rutos.sensor import (
     RutOSModemSignalSensor,
     RutOSModemStatusSensor,
     RutOSSensorEntity,
+    _format_bands,
 )
+
+
+def _bands_desc():
+    """Locate the bands entity description by key."""
+    return next(d for d in MODEM_SIGNAL_SENSORS if d.key == "bands")
+
+
+def _band_desc():
+    """Locate the legacy single-band entity description by key."""
+    return next(d for d in MODEM_SIGNAL_SENSORS if d.key == "band")
 
 
 class TestRutOSSensorEntity:
@@ -375,3 +386,85 @@ class TestModemSensorNaming:
         sensor = RutOSModemStatusSensor(mock_coordinator, desc, "2-1")
         assert sensor.translation_key == "modem_operator_multi"
         assert sensor.translation_placeholders == {"modem": "2-1"}
+
+
+class TestFormatBands:
+    """Pure unit tests for the band-list formatter."""
+
+    def test_empty_carriers_returns_fallback(self):
+        assert _format_bands([], "B7") == "B7"
+        assert _format_bands([], None) is None
+
+    def test_single_lte_carrier(self):
+        carriers = [{"band": "LTE B7", "primary": True}]
+        assert _format_bands(carriers, None) == "LTE 7 (P)"
+
+    def test_nsa_3ca_lte_plus_2x_n78(self):
+        """5G-NSA with 3CA LTE (PCell B7) + intra-band 2x N78 NR."""
+        carriers = [
+            {"band": "LTE B7", "primary": True},
+            {"band": "LTE B2", "primary": False},
+            {"band": "LTE B66", "primary": False},
+            {"band": "5G N78", "primary": False},
+            {"band": "5G N78", "primary": False},
+        ]
+        assert _format_bands(carriers, None) == "LTE 7 (P), 2, 66 + 5G 78×2"
+
+    def test_unparseable_band_is_skipped(self):
+        carriers = [
+            {"band": "LTE B7", "primary": True},
+            {"band": "garbage", "primary": False},
+            {"band": None, "primary": False},
+        ]
+        assert _format_bands(carriers, None) == "LTE 7 (P)"
+
+    def test_all_unparseable_falls_back(self):
+        carriers = [{"band": "garbage"}]
+        assert _format_bands(carriers, "B7") == "B7"
+
+
+class TestRutOSBandsSensor:
+    """Tests for the carrier-aggregation bands sensor."""
+
+    def test_native_value_with_carriers(
+        self,
+        mock_coordinator: RutOSDataUpdateCoordinator,
+        mock_modem_signal_nsa_ca,
+    ):
+        mock_coordinator.data.modem_signal = mock_modem_signal_nsa_ca
+        sensor = RutOSModemSignalSensor(mock_coordinator, _bands_desc(), "modem1")
+        assert sensor.native_value == "LTE 7 (P), 2, 66 + 5G 78×2"
+
+    def test_native_value_without_carriers_falls_back(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Non-CA modem: sensor falls back to the top-level band string."""
+        sensor = RutOSModemSignalSensor(mock_coordinator, _bands_desc(), "modem1")
+        assert sensor.native_value == "B7"
+
+    def test_extra_state_attributes(
+        self,
+        mock_coordinator: RutOSDataUpdateCoordinator,
+        mock_modem_signal_nsa_ca,
+    ):
+        mock_coordinator.data.modem_signal = mock_modem_signal_nsa_ca
+        sensor = RutOSModemSignalSensor(mock_coordinator, _bands_desc(), "modem1")
+        attrs = sensor.extra_state_attributes
+        assert attrs is not None
+        assert attrs["primary_band"] == "LTE B7"
+        assert len(attrs["carriers"]) == 5
+        assert attrs["carriers"][0]["band"] == "LTE B7"
+
+    def test_legacy_band_sensor_has_no_attributes(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        """Sensors without attributes_fn should not expose extras."""
+        sensor = RutOSModemSignalSensor(mock_coordinator, _band_desc(), "modem1")
+        assert sensor.extra_state_attributes is None
+
+    def test_missing_modem_returns_none(
+        self, mock_coordinator: RutOSDataUpdateCoordinator
+    ):
+        sensor = RutOSModemSignalSensor(mock_coordinator, _bands_desc(), "nope")
+        assert sensor.native_value is None
+        assert sensor.extra_state_attributes is None


### PR DESCRIPTION
## Summary

- New `bands` sensor: compact carrier-aggregation display string (e.g. `"LTE 7 (P), 2, 66 + 5G 78×2"`) with structured `carriers` + `primary_band` attributes for template/markdown cards.
- API now normalizes `/modems/status` `ca_signal` into a `carriers` list on every modem dict.
- Fixes 5G-NSA band mislabeling: the existing `band` sensor now reports the primary PCell instead of the NR anchor.

## Breaking change

The existing `band` sensor previously reported the top-level `band` field from `/modems/status`. On 5G-NSA this was the NR anchor (e.g. `"5G N78"`). It now reports the primary carrier from `ca_signal` (e.g. `"LTE B7"`). Automations keyed on the old NSA value will need updating.

On non-CA or LTE-only setups, the `band` value is unchanged.

## Test plan

- [x] `.venv/bin/python -m pytest tests/` — 213 passing
- [x] `.venv/bin/ruff check` + `ruff format --check` — clean on touched files
- [x] `pyright custom_components/rutos/` — 0 errors
- [x] Live smoke test against an RG520N-NA on Bell 5G-NSA: returns `"LTE 7 (P), 2, 66 + 5G 78×2"` as expected
- [x] Install on a live HA instance and verify `sensor.<modem>_bands` state + `state_attr(..., 'carriers')`

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)