### PR TITLE
Update repository URLs to tailgatelabs org

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,7 @@ from the latest release on `main` by default. To test a different branch:
 
    ```bash
    rm -rf /config/custom_components/rutos
-   git clone https://github.com/crbn60/ha-rutos-integration.git /tmp/rutos-repo
+   git clone https://github.com/tailgatelabs/ha-rutos-integration.git /tmp/rutos-repo
    cp -r /tmp/rutos-repo/custom_components/rutos /config/custom_components/rutos
    rm -rf /tmp/rutos-repo
    ```
@@ -106,7 +106,7 @@ from the latest release on `main` by default. To test a different branch:
 
    ```bash
    cd /tmp  # use a temp clone to grab the branch
-   git clone -b my-feature https://github.com/crbn60/ha-rutos-integration.git rutos-repo
+   git clone -b my-feature https://github.com/tailgatelabs/ha-rutos-integration.git rutos-repo
    rm -rf /config/custom_components/rutos
    cp -r rutos-repo/custom_components/rutos /config/custom_components/rutos
    rm -rf rutos-repo
@@ -119,7 +119,7 @@ from the latest release on `main` by default. To test a different branch:
 1. Clone the repo on your development machine:
 
    ```bash
-   git clone https://github.com/crbn60/ha-rutos-integration.git
+   git clone https://github.com/tailgatelabs/ha-rutos-integration.git
    cd ha-rutos-integration
    git checkout dev  # or any branch/PR
    ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RutOS Home Assistant Integration
 
-[![Validate](https://github.com/crbn60/ha-rutos-integration/actions/workflows/validate.yml/badge.svg)](https://github.com/crbn60/ha-rutos-integration/actions/workflows/validate.yml)
+[![Validate](https://github.com/tailgatelabs/ha-rutos-integration/actions/workflows/validate.yml/badge.svg)](https://github.com/tailgatelabs/ha-rutos-integration/actions/workflows/validate.yml)
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-41BDF5.svg)](https://github.com/hacs/integration)
 
 A Home Assistant custom integration for Teltonika devices running RutOS.
@@ -48,7 +48,8 @@ control, GPS tracking, cellular monitoring, and SMS notifications.
 
 1. Open HACS in Home Assistant
 2. Go to **Integrations** > **Custom repositories**
-3. Add `https://github.com/crbn60/ha-rutos-integration` as an **Integration**
+3. Add `https://github.com/tailgatelabs/ha-rutos-integration` as an
+   **Integration**
 4. Search for "RutOS" and install it
 5. Restart Home Assistant
 

--- a/custom_components/rutos/manifest.json
+++ b/custom_components/rutos/manifest.json
@@ -3,10 +3,10 @@
   "name": "RutOS",
   "codeowners": ["@crbn60"],
   "config_flow": true,
-  "documentation": "https://github.com/crbn60/ha-rutos-integration",
+  "documentation": "https://github.com/tailgatelabs/ha-rutos-integration",
   "integration_type": "hub",
   "iot_class": "local_polling",
-  "issue_tracker": "https://github.com/crbn60/ha-rutos-integration/issues",
+  "issue_tracker": "https://github.com/tailgatelabs/ha-rutos-integration/issues",
   "loggers": ["custom_components.rutos"],
   "version": "0.1.0"
 }


### PR DESCRIPTION
## Summary
- Repo moved from `crbn60` to the `tailgatelabs` organization. This PR updates every repo-URL reference so badges, HACS install instructions, clone commands, and Home Assistant manifest metadata all point at the new location.
- Files touched: `README.md` (CI badge + HACS install URL), `CONTRIBUTING.md` (three `git clone` examples), `custom_components/rutos/manifest.json` (`documentation` + `issue_tracker`).
- `manifest.json` `codeowners` still lists `@crbn60` — left untouched since it's a GitHub handle, not a URL. Change separately if the maintainer handle should move too.

## Test plan
- [x] CI Validate badge renders and links to the new `tailgatelabs` Actions URL
- [x] HACS custom-repository install using the new URL succeeds on a fresh HA instance
- [x] "Documentation" and "Report an issue" links from the HA integration page open the tailgatelabs repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)