### PR TITLE
Enforce Python type hints via ruff ANN rules and stricter pyright

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -35,3 +35,16 @@ jobs:
       - run:
           pytest tests/ -v --cov=custom_components/rutos --cov-report=xml
           --cov-report=term-missing
+
+  typecheck:
+    name: Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+      - run: pip install -r requirements_dev.txt -r requirements_test.txt
+      - uses: jakebailey/pyright-action@v2
+        with:
+          project: pyrightconfig.json

--- a/custom_components/rutos/api.py
+++ b/custom_components/rutos/api.py
@@ -108,7 +108,7 @@ class RutOSAPI:
         self,
         method: str,
         path: str,
-        json_data: dict | None = None,
+        json_data: dict[str, Any] | None = None,
     ) -> Any:
         """Send an authenticated HTTP request, retrying once on 401."""
         url = self._url(path)

--- a/custom_components/rutos/coordinator.py
+++ b/custom_components/rutos/coordinator.py
@@ -17,6 +17,17 @@ from .const import DEFAULT_SCAN_INTERVAL, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
+type _UpdateResult = tuple[
+    list[dict[str, Any]],
+    bool,
+    dict[str, Any] | None,
+    list[dict[str, Any]],
+    list[dict[str, Any]],
+    list[dict[str, Any]],
+    list[dict[str, Any]],
+    list[dict[str, Any]],
+]
+
 
 @dataclass
 class RutOSData:
@@ -65,19 +76,9 @@ class RutOSDataUpdateCoordinator(DataUpdateCoordinator[RutOSData]):
         if self.data is None:
             self.data = RutOSData()
 
-        _ResultT = tuple[
-            list[dict[str, Any]],
-            bool,
-            dict[str, Any] | None,
-            list[dict[str, Any]],
-            list[dict[str, Any]],
-            list[dict[str, Any]],
-            list[dict[str, Any]],
-            list[dict[str, Any]],
-        ]
         try:
             results = cast(
-                _ResultT,
+                _UpdateResult,
                 await asyncio.gather(
                     self.api.get_wan_interfaces(),
                     self.api.get_internet_status(),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,14 @@
+[tool.ruff.lint]
+extend-select = [
+    "ANN001",  # missing type annotation for function argument
+    "ANN201",  # missing return type for public function
+    "ANN202",  # missing return type for private function
+    "ANN204",  # missing return type for special method
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["ANN001", "ANN201", "ANN202", "ANN204"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -3,5 +3,9 @@
   "venvPath": ".",
   "venv": ".venv",
   "pythonVersion": "3.14",
-  "typeCheckingMode": "basic"
+  "typeCheckingMode": "basic",
+  "reportMissingParameterType": "error",
+  "reportMissingTypeArgument": "error",
+  "reportUnknownParameterType": "error",
+  "reportInvalidTypeForm": "error"
 }


### PR DESCRIPTION
## Summary
- Tighten `pyrightconfig.json`: promote `reportMissingParameterType`, `reportMissingTypeArgument`, `reportUnknownParameterType`, and `reportInvalidTypeForm` to errors (keeping `typeCheckingMode: basic` so HA's `cached_property` vs `@property` friction doesn't create noise)
- Add `[tool.ruff.lint]` with `ANN001/201/202/204` so missing parameter/return annotations fail lint; `tests/**` is exempted via `per-file-ignores`
- New `typecheck` CI job runs `jakebailey/pyright-action@v2` against `pyrightconfig.json` in parallel with the existing test job
- Fix the two pre-existing gaps the new rules surface:
  - `coordinator.py` — local `_ResultT = tuple[...]` used inside `cast()` was flagged by latest pyright as `reportInvalidTypeForm`; hoisted to module scope as PEP 695 `type _UpdateResult = ...`
  - `api.py` — `RutOSAPI._request.json_data: dict | None` → `dict[str, Any] | None`

## Test plan
- [x] `.venv/bin/ruff check custom_components/rutos/ tests/` — clean
- [x] `pyright custom_components/rutos/` (v1.1.408) — 0 errors
- [x] `.venv/bin/python -m pytest tests/ -q` — 213 passed
- [x] CI: `typecheck` job runs green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)