### PR TITLE
Fix #38: discover failover members via mwan3 policies

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -3,15 +3,18 @@ project_name: "ha-rutos-integration"
 
 
 # list of languages for which language servers are started; choose from:
-#   al                  bash                clojure             cpp                 csharp
-#   csharp_omnisharp    dart                elixir              elm                 erlang
-#   fortran             fsharp              go                  groovy              haskell
-#   java                julia               kotlin              lua                 markdown
-#   matlab              nix                 pascal              perl                php
-#   php_phpactor        powershell          python              python_jedi         r
-#   rego                ruby                ruby_solargraph     rust                scala
-#   swift               terraform           toml                typescript          typescript_vts
-#   vue                 yaml                zig
+#   al                  ansible             bash                clojure             cpp
+#   cpp_ccls            crystal             csharp              csharp_omnisharp    dart
+#   elixir              elm                 erlang              fortran             fsharp
+#   go                  groovy              haskell             haxe                hlsl
+#   java                json                julia               kotlin              lean4
+#   lua                 luau                markdown            matlab              msl
+#   nix                 ocaml               pascal              perl                php
+#   php_phpactor        powershell          python              python_jedi         python_ty
+#   r                   rego                ruby                ruby_solargraph     rust
+#   scala               solidity            swift               systemverilog       terraform
+#   toml                typescript          typescript_vts      vue                 yaml
+#   zig
 #   (This list may be outdated. For the current list, see values of Language enum here:
 #   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
 #   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
@@ -54,53 +57,17 @@ read_only: false
 
 # list of tool names to exclude.
 # This extends the existing exclusions (e.g. from the global configuration)
-#
-# Below is the complete list of tools for convenience.
-# To make sure you have the latest list of tools, and to view their descriptions, 
-# execute `uv run scripts/print_tool_overview.py`.
-#
-#  * `activate_project`: Activates a project by name.
-#  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
-#  * `create_text_file`: Creates/overwrites a file in the project directory.
-#  * `delete_lines`: Deletes a range of lines within a file.
-#  * `delete_memory`: Deletes a memory from Serena's project-specific memory store.
-#  * `execute_shell_command`: Executes a shell command.
-#  * `find_referencing_code_snippets`: Finds code snippets in which the symbol at the given location is referenced.
-#  * `find_referencing_symbols`: Finds symbols that reference the symbol at the given location (optionally filtered by type).
-#  * `find_symbol`: Performs a global (or local) search for symbols with/containing a given name/substring (optionally filtered by type).
-#  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
-#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
-#  * `initial_instructions`: Gets the initial instructions for the current project.
-#     Should only be used in settings where the system prompt cannot be set,
-#     e.g. in clients you have no control over, like Claude Desktop.
-#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
-#  * `insert_at_line`: Inserts content at a given line in a file.
-#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
-#  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
-#  * `list_memories`: Lists memories in Serena's project-specific memory store.
-#  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
-#  * `prepare_for_new_conversation`: Provides instructions for preparing for a new conversation (in order to continue with the necessary context).
-#  * `read_file`: Reads a file within the project directory.
-#  * `read_memory`: Reads the memory with the given name from Serena's project-specific memory store.
-#  * `remove_project`: Removes a project from the Serena configuration.
-#  * `replace_lines`: Replaces a range of lines within a file with new content.
-#  * `replace_symbol_body`: Replaces the full definition of a symbol.
-#  * `restart_language_server`: Restarts the language server, may be necessary when edits not through Serena happen.
-#  * `search_for_pattern`: Performs a search for a pattern in the project.
-#  * `summarize_changes`: Provides instructions for summarizing the changes made to the codebase.
-#  * `switch_modes`: Activates modes by providing a list of their names
-#  * `think_about_collected_information`: Thinking tool for pondering the completeness of collected information.
-#  * `think_about_task_adherence`: Thinking tool for determining whether the agent is still on track with the current task.
-#  * `think_about_whether_you_are_done`: Thinking tool for determining whether the task is truly completed.
-#  * `write_memory`: Writes a named memory (for future reference) to Serena's project-specific memory store.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 excluded_tools: []
 
 # list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
 # This extends the existing inclusions (e.g. from the global configuration).
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 included_optional_tools: []
 
 # fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
 # This cannot be combined with non-empty excluded_tools or included_optional_tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 fixed_tools: []
 
 # list of mode names to that are always to be included in the set of active modes
@@ -111,11 +78,14 @@ fixed_tools: []
 # Set this to a list of mode names to always include the respective modes for this project.
 base_modes:
 
-# list of mode names that are to be activated by default.
-# The full set of modes to be activated is base_modes + default_modes.
-# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
+# list of mode names that are to be activated by default, overriding the setting in the global configuration.
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# If the setting is undefined/empty, the default_modes from the global configuration (serena_config.yml) apply.
 # Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# Therefore, you can set this to [] if you do not want the default modes defined in the global config to apply
+# for this project.
 # This setting can, in turn, be overridden by CLI parameters (--mode).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
 default_modes:
 
 # initial prompt for the project. It will always be given to the LLM upon activating the project
@@ -150,3 +120,8 @@ ignored_memory_patterns: []
 # Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
 # No documentation on options means no options are available.
 ls_specific_settings: {}
+
+# list of mode names to be activated additionally for this project, e.g. ["query-projects"]
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+added_modes:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,24 @@ HACS.
 - **HACS validate:**
   `docker run --rm -v $(pwd):/github/workspace ghcr.io/hacs/action`
 
+## Test Router
+
+A live Teltonika router is reachable for ad-hoc API checks (e.g. comparing raw
+endpoint responses against what the integration expects). Credentials live in
+`.env` (gitignored) as `TELTONIKA_HOST`, `TELTONIKA_USER`, `TELTONIKA_PASSWORD`.
+Read-only account; safe to query freely. Self-signed cert, so use `curl -k`.
+
+To call an endpoint:
+
+```bash
+set -a; . ./.env; set +a
+TOKEN=$(curl -sk -X POST "https://$TELTONIKA_HOST/api/login" \
+  -H "Content-Type: application/json" \
+  -d "{\"username\":\"$TELTONIKA_USER\",\"password\":\"$TELTONIKA_PASSWORD\"}" \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['data']['token'])")
+curl -sk "https://$TELTONIKA_HOST/api/<path>" -H "Authorization: Bearer $TOKEN"
+```
+
 ## Conventions
 
 - All entities inherit from `RutOSEntity` base class (`entity.py`) which

--- a/custom_components/rutos/__init__.py
+++ b/custom_components/rutos/__init__.py
@@ -188,9 +188,9 @@ def _register_services(hass: HomeAssistant) -> None:
                 )
 
             iface_to_member: dict[str, str] = {
-                m["interface"]: m["id"]
+                m["network_id"]: m["id"]
                 for m in coordinator.data.failover_members
-                if m.get("interface") and m.get("id")
+                if m.get("network_id") and m.get("id")
             }
             unknown = [i for i in interfaces if i not in iface_to_member]
             if unknown:

--- a/custom_components/rutos/__init__.py
+++ b/custom_components/rutos/__init__.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.util import slugify
 
@@ -179,7 +180,27 @@ def _register_services(hass: HomeAssistant) -> None:
 
         for entry in hass.config_entries.async_entries(DOMAIN):
             coordinator: RutOSDataUpdateCoordinator = entry.runtime_data
-            await coordinator.api.set_failover_order(interfaces)
+            if coordinator.data.failover_mode == "balance":
+                raise ServiceValidationError(
+                    "Cannot set failover order: router's active mwan3 policy "
+                    "is in load-balance mode. Switch to failover mode in the "
+                    "router GUI to use this service."
+                )
+
+            iface_to_member: dict[str, str] = {
+                m["interface"]: m["id"]
+                for m in coordinator.data.failover_members
+                if m.get("interface") and m.get("id")
+            }
+            unknown = [i for i in interfaces if i not in iface_to_member]
+            if unknown:
+                raise ServiceValidationError(
+                    f"Cannot set failover order: interface(s) {unknown} are "
+                    "not in the active failover policy."
+                )
+
+            member_ids = [iface_to_member[i] for i in interfaces]
+            await coordinator.api.set_failover_order(member_ids)
             await coordinator.async_request_refresh()
 
     hass.services.async_register(

--- a/custom_components/rutos/api.py
+++ b/custom_components/rutos/api.py
@@ -62,6 +62,42 @@ def _normalize_carriers(ca_signal: Any) -> list[dict[str, Any]]:
     return out
 
 
+def _resolve_active_policy_id(
+    rules: list[dict[str, Any]], policies: list[dict[str, Any]]
+) -> str | None:
+    """Pick the policy that drives default-bound traffic.
+
+    Prefers the rule named ``default_rule`` (Teltonika's catch-all), falls
+    back to the first rule, then to the only policy if exactly one exists.
+    """
+    if rules:
+        default_rule = next((r for r in rules if r.get("name") == "default_rule"), None)
+        rule = default_rule or rules[0]
+        policy_id = rule.get("use_policy")
+        if isinstance(policy_id, str) and policy_id:
+            return policy_id
+    if len(policies) == 1:
+        policy_id = policies[0].get("id")
+        if isinstance(policy_id, str) and policy_id:
+            return policy_id
+    return None
+
+
+def _detect_failover_mode(members: list[dict[str, Any]]) -> str:
+    """Return ``"balance"`` when members share the same metric, else ``"failover"``.
+
+    A load-balance policy assigns equal metrics to all members and uses
+    ``weight`` for traffic share; failover policies use distinct metrics for
+    priority. With fewer than 2 members the distinction is meaningless;
+    default to ``"failover"`` so the integration shows whatever single
+    interface exists.
+    """
+    if len(members) < 2:  # noqa: PLR2004
+        return "failover"
+    metrics = {m.get("metric") for m in members}
+    return "balance" if len(metrics) == 1 else "failover"
+
+
 class RutOSAPIError(Exception):
     """Base exception for RutOS API errors."""
 
@@ -483,20 +519,76 @@ class RutOSAPI:
             )
         return modems
 
-    async def set_failover_order(self, interfaces: list[str]) -> None:
-        """Set the failover order by updating mwan3 member metrics."""
+    async def set_failover_order(self, member_ids: list[str]) -> None:
+        """Set the failover order by updating mwan3 member metrics.
+
+        Caller must pass the active policy's member IDs (resolved via
+        ``get_active_failover_chain``) in the desired priority order.
+        """
         members = [
-            {"id": f"{iface_id}_member_mwan", "metric": str(idx + 1)}
-            for idx, iface_id in enumerate(interfaces)
+            {"id": member_id, "metric": str(idx + 1)}
+            for idx, member_id in enumerate(member_ids)
         ]
         await self.put("/failover/members/config", {"data": members})
 
-    async def get_failover_members(self) -> list[dict[str, Any]]:
-        """Fetch mwan3 failover member configs (priority metrics)."""
+    async def get_failover_policies(self) -> list[dict[str, Any]]:
+        """Fetch mwan3 policy configs."""
+        data = await self.get("/failover/policies/config")
+        if not isinstance(data, list):
+            return []
+        return data
+
+    async def get_failover_rules(self) -> list[dict[str, Any]]:
+        """Fetch mwan3 rule configs (which traffic uses which policy)."""
+        data = await self.get("/failover/rules/config")
+        if not isinstance(data, list):
+            return []
+        return data
+
+    async def get_active_failover_chain(self) -> dict[str, Any]:
+        """Resolve the active failover chain.
+
+        Reads policies and rules, picks the active policy from the default
+        rule (or first rule, or the only policy), and returns its members
+        in policy-defined order along with a mode flag.
+
+        Returns a dict with keys:
+            policy_id: str | None - active policy id, None if not resolvable
+            mode: "failover" | "balance" - balance when all members share metric
+            members: list[dict] - member dicts (id, interface, metric, ...) in
+                policy order, filtered to only those in use_member.
+        """
+        policies, rules, all_members = await asyncio.gather(
+            self.get_failover_policies(),
+            self.get_failover_rules(),
+            self._get_all_failover_members(),
+        )
+
+        policy_id = _resolve_active_policy_id(rules, policies)
+        if policy_id is None:
+            return {"policy_id": None, "mode": "failover", "members": []}
+
+        policy = next((p for p in policies if p.get("id") == policy_id), None)
+        if policy is None:
+            return {"policy_id": None, "mode": "failover", "members": []}
+
+        use_member = policy.get("use_member") or []
+        members_by_id = {m.get("id"): m for m in all_members}
+        ordered_members: list[dict[str, Any]] = []
+        for member_id in use_member:
+            member = members_by_id.get(member_id)
+            if member is not None:
+                ordered_members.append(member)
+
+        mode = _detect_failover_mode(ordered_members)
+        return {"policy_id": policy_id, "mode": mode, "members": ordered_members}
+
+    async def _get_all_failover_members(self) -> list[dict[str, Any]]:
+        """Fetch all mwan3 member configs (no naming-based filter)."""
         data = await self.get("/failover/members/config")
         if not isinstance(data, list):
             return []
-        return [m for m in data if m.get("id", "").endswith("_member_mwan")]
+        return data
 
     async def get_gps_position(self) -> dict[str, Any] | None:
         """Fetch GPS position data (lat, lon, speed, altitude, etc.)."""

--- a/custom_components/rutos/api.py
+++ b/custom_components/rutos/api.py
@@ -545,24 +545,47 @@ class RutOSAPI:
             return []
         return data
 
+    async def get_failover_interfaces(self) -> list[dict[str, Any]]:
+        """Fetch mwan3 interface configs (the bridge to network interfaces).
+
+        Each entry has ``id`` (matches network interface UCI id) and ``name``
+        (matches the display name used in ``mwan_member.interface``).
+        """
+        data = await self.get("/failover/interfaces/config")
+        if not isinstance(data, list):
+            return []
+        return data
+
     async def get_active_failover_chain(self) -> dict[str, Any]:
         """Resolve the active failover chain.
 
-        Reads policies and rules, picks the active policy from the default
-        rule (or first rule, or the only policy), and returns its members
-        in policy-defined order along with a mode flag.
+        Reads policies, rules, members, and the mwan_interface bridge table,
+        picks the active policy from the default rule (or first rule, or the
+        only policy), and returns its members in policy-defined order. Each
+        returned member has a ``network_id`` field set to the UCI id of the
+        underlying network interface — derived by mapping
+        ``mwan_member.interface`` (a display name) through
+        ``mwan_interface.name`` to ``mwan_interface.id``. ``network_id`` is
+        ``None`` when the bridge entry is missing.
 
         Returns a dict with keys:
             policy_id: str | None - active policy id, None if not resolvable
             mode: "failover" | "balance" - balance when all members share metric
-            members: list[dict] - member dicts (id, interface, metric, ...) in
-                policy order, filtered to only those in use_member.
+            members: list[dict] - member dicts in policy order with
+                ``network_id`` attached.
         """
-        policies, rules, all_members = await asyncio.gather(
+        policies, rules, all_members, fo_interfaces = await asyncio.gather(
             self.get_failover_policies(),
             self.get_failover_rules(),
             self._get_all_failover_members(),
+            self.get_failover_interfaces(),
         )
+
+        network_id_by_mwan_name = {
+            fi.get("name"): fi.get("id")
+            for fi in fo_interfaces
+            if isinstance(fi.get("name"), str) and isinstance(fi.get("id"), str)
+        }
 
         policy_id = _resolve_active_policy_id(rules, policies)
         if policy_id is None:
@@ -578,7 +601,11 @@ class RutOSAPI:
         for member_id in use_member:
             member = members_by_id.get(member_id)
             if member is not None:
-                ordered_members.append(member)
+                resolved = dict(member)
+                resolved["network_id"] = network_id_by_mwan_name.get(
+                    member.get("interface")
+                )
+                ordered_members.append(resolved)
 
         mode = _detect_failover_mode(ordered_members)
         return {"policy_id": policy_id, "mode": mode, "members": ordered_members}

--- a/custom_components/rutos/config_flow.py
+++ b/custom_components/rutos/config_flow.py
@@ -172,10 +172,15 @@ class RutOSOptionsFlowHandler(OptionsFlow):
                 return self.async_create_entry(title="", data=self._options_data)
 
         # Use members from the active failover policy, restricted to interfaces
-        # currently present on the router.
-        members = coordinator.data.failover_members
-        active_ifaces = {iface["name"] for iface in coordinator.data.wan_interfaces}
-        members = [m for m in members if m.get("interface", "") in active_ifaces]
+        # currently present on the router. Members carry a ``network_id``
+        # resolved through the mwan_interface bridge table; that's the UCI id
+        # which lines up with ``wan_interfaces[i]["name"]``.
+        active_ids = {iface["name"] for iface in coordinator.data.wan_interfaces}
+        members = [
+            m
+            for m in coordinator.data.failover_members
+            if m.get("network_id") in active_ids
+        ]
 
         # Build reverse map: iface_id → existing label
         existing_groups: dict[str, list[str]] = self.config_entry.options.get(
@@ -186,10 +191,11 @@ class RutOSOptionsFlowHandler(OptionsFlow):
             for iface in ifaces:
                 existing_labels[iface] = label
 
-        # Build dynamic schema: one text field per interface
+        # Build dynamic schema: one text field per interface, keyed by the
+        # canonical UCI id (stable across user-driven display name changes).
         schema: dict[vol.Required, type] = {}
         for member in sorted(members, key=lambda m: int(m.get("metric", 0))):
-            iface_id = member.get("interface", member.get("id", ""))
+            iface_id = member["network_id"]
             default = existing_labels.get(iface_id, iface_id)
             if user_input and iface_id in user_input:
                 default = user_input[iface_id]

--- a/custom_components/rutos/config_flow.py
+++ b/custom_components/rutos/config_flow.py
@@ -144,6 +144,10 @@ class RutOSOptionsFlowHandler(OptionsFlow):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Configure failover interface groups."""
+        coordinator = self.config_entry.runtime_data
+        if coordinator.data.failover_mode == "balance":
+            return await self.async_step_failover_balance(user_input)
+
         errors: dict[str, str] = {}
 
         if user_input is not None:
@@ -167,9 +171,9 @@ class RutOSOptionsFlowHandler(OptionsFlow):
                 self._options_data[CONF_FAILOVER_GROUPS] = groups
                 return self.async_create_entry(title="", data=self._options_data)
 
-        # Fetch current failover members, excluding disabled interfaces
-        coordinator = self.config_entry.runtime_data
-        members = await coordinator.api.get_failover_members()
+        # Use members from the active failover policy, restricted to interfaces
+        # currently present on the router.
+        members = coordinator.data.failover_members
         active_ifaces = {iface["name"] for iface in coordinator.data.wan_interfaces}
         members = [m for m in members if m.get("interface", "") in active_ifaces]
 
@@ -195,6 +199,20 @@ class RutOSOptionsFlowHandler(OptionsFlow):
             step_id="failover_groups",
             data_schema=vol.Schema(schema),
             errors=errors,
+        )
+
+    async def async_step_failover_balance(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the case where the active policy is load-balance mode."""
+        if user_input is not None:
+            self._options_data[CONF_FAILOVER_GROUPS] = self.config_entry.options.get(
+                CONF_FAILOVER_GROUPS, {}
+            )
+            return self.async_create_entry(title="", data=self._options_data)
+        return self.async_show_form(
+            step_id="failover_balance",
+            data_schema=vol.Schema({}),
         )
 
 

--- a/custom_components/rutos/coordinator.py
+++ b/custom_components/rutos/coordinator.py
@@ -25,7 +25,7 @@ type _UpdateResult = tuple[
     list[dict[str, Any]],
     list[dict[str, Any]],
     list[dict[str, Any]],
-    list[dict[str, Any]],
+    dict[str, Any],
 ]
 
 
@@ -41,7 +41,19 @@ class RutOSData:
     modem_signal: list[dict[str, Any]] = field(default_factory=list)
     modem_status: list[dict[str, Any]] = field(default_factory=list)
     modems: list[dict[str, Any]] = field(default_factory=list)
-    failover_members: list[dict[str, Any]] = field(default_factory=list)
+    failover_chain: dict[str, Any] = field(
+        default_factory=lambda: {"policy_id": None, "mode": "failover", "members": []}
+    )
+
+    @property
+    def failover_members(self) -> list[dict[str, Any]]:
+        """Return the active policy's failover members in policy order."""
+        return self.failover_chain.get("members", [])
+
+    @property
+    def failover_mode(self) -> str:
+        """Return ``"failover"`` or ``"balance"`` for the active policy."""
+        return self.failover_chain.get("mode", "failover")
 
 
 class RutOSDataUpdateCoordinator(DataUpdateCoordinator[RutOSData]):
@@ -87,7 +99,7 @@ class RutOSDataUpdateCoordinator(DataUpdateCoordinator[RutOSData]):
                     self.api.get_modem_signal(),
                     self.api.get_modem_status(),
                     self.api.get_modems(),
-                    self.api.get_failover_members(),
+                    self.api.get_active_failover_chain(),
                 ),
             )
         except RutOSAuthError as err:
@@ -103,6 +115,6 @@ class RutOSDataUpdateCoordinator(DataUpdateCoordinator[RutOSData]):
             self.data.modem_signal,
             self.data.modem_status,
             self.data.modems,
-            self.data.failover_members,
+            self.data.failover_chain,
         ) = results
         return self.data

--- a/custom_components/rutos/select.py
+++ b/custom_components/rutos/select.py
@@ -23,6 +23,8 @@ async def async_setup_entry(
     groups: dict[str, list[str]] = entry.options.get(CONF_FAILOVER_GROUPS, {})
     if len(groups) < 2:  # noqa: PLR2004
         return
+    if entry.runtime_data.data.failover_mode == "balance":
+        return
     async_add_entities([RutOSFailoverSelect(entry.runtime_data, groups)])
 
 
@@ -99,8 +101,16 @@ class RutOSFailoverSelect(RutOSEntity, SelectEntity):
     async def async_select_option(self, option: str) -> None:
         """Set the failover order for the selected permutation."""
         group_order = [g.strip() for g in option.split(", ")]
-        interfaces: list[str] = []
+        iface_to_member: dict[str, str] = {
+            m["interface"]: m["id"]
+            for m in self.coordinator.data.failover_members
+            if m.get("interface") and m.get("id")
+        }
+        member_ids: list[str] = []
         for label in group_order:
-            interfaces.extend(self._groups[label])
-        await self.coordinator.api.set_failover_order(interfaces)
+            for iface in self._groups[label]:
+                member_id = iface_to_member.get(iface)
+                if member_id:
+                    member_ids.append(member_id)
+        await self.coordinator.api.set_failover_order(member_ids)
         await self.coordinator.async_request_refresh()

--- a/custom_components/rutos/select.py
+++ b/custom_components/rutos/select.py
@@ -6,6 +6,7 @@ import itertools
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import RutOSConfigEntry
@@ -72,7 +73,9 @@ class RutOSFailoverSelect(RutOSEntity, SelectEntity):
 
     @property
     def available(self) -> bool:
-        """Return False if fewer than 2 groups are active."""
+        """Return False if balance mode is active or fewer than 2 groups are active."""
+        if self.coordinator.data.failover_mode == "balance":
+            return False
         return len(self._active_groups()) >= 2  # noqa: PLR2004
 
     @property
@@ -100,6 +103,11 @@ class RutOSFailoverSelect(RutOSEntity, SelectEntity):
 
     async def async_select_option(self, option: str) -> None:
         """Set the failover order for the selected permutation."""
+        if self.coordinator.data.failover_mode == "balance":
+            raise HomeAssistantError(
+                "Cannot set failover order: router's active mwan3 policy "
+                "is in load-balance mode."
+            )
         group_order = [g.strip() for g in option.split(", ")]
         iface_to_member: dict[str, str] = {
             m["interface"]: m["id"]

--- a/custom_components/rutos/select.py
+++ b/custom_components/rutos/select.py
@@ -83,7 +83,9 @@ class RutOSFailoverSelect(RutOSEntity, SelectEntity):
         """Determine the current option from mwan3 member metrics."""
         members = self.coordinator.data.failover_members
         iface_metrics = {
-            m.get("interface", ""): int(m.get("metric", 0)) for m in members
+            m["network_id"]: int(m.get("metric", 0))
+            for m in members
+            if m.get("network_id")
         }
 
         active = self._active_groups()
@@ -110,9 +112,9 @@ class RutOSFailoverSelect(RutOSEntity, SelectEntity):
             )
         group_order = [g.strip() for g in option.split(", ")]
         iface_to_member: dict[str, str] = {
-            m["interface"]: m["id"]
+            m["network_id"]: m["id"]
             for m in self.coordinator.data.failover_members
-            if m.get("interface") and m.get("id")
+            if m.get("network_id") and m.get("id")
         }
         member_ids: list[str] = []
         for label in group_order:

--- a/custom_components/rutos/strings.json
+++ b/custom_components/rutos/strings.json
@@ -30,6 +30,10 @@
       "failover_groups": {
         "title": "Failover groups",
         "description": "Assign a label to each failover interface. Interfaces with the same label are grouped and reordered together."
+      },
+      "failover_balance": {
+        "title": "Failover priority unavailable",
+        "description": "The router's active mwan3 policy is configured for load balancing, not failover. Priority cannot be set in this mode. Switch the router to mwan failover mode to enable this feature."
       }
     },
     "error": {

--- a/custom_components/rutos/translations/en.json
+++ b/custom_components/rutos/translations/en.json
@@ -77,6 +77,10 @@
       "failover_groups": {
         "title": "Failover groups",
         "description": "Assign a label to each failover interface. Interfaces with the same label are grouped and reordered together."
+      },
+      "failover_balance": {
+        "title": "Failover priority unavailable",
+        "description": "The router's active mwan3 policy is configured for load balancing, not failover. Priority cannot be set in this mode. Switch the router to mwan failover mode to enable this feature."
       }
     },
     "error": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -228,12 +228,39 @@ def mock_modems() -> list[dict]:
 
 @pytest.fixture
 def mock_failover_members() -> list[dict]:
-    """Return mock failover member data (failover-mode policy)."""
+    """Return mock failover member data (failover-mode policy).
+
+    Note ``interface`` holds the mwan_interface display name (the user-facing
+    name), while ``network_id`` is the canonical UCI id resolved through the
+    mwan_interface bridge table — that's what the integration uses to match
+    against ``wan_interfaces[i]["name"]``. The ``wan2``/``wifi1`` row is the
+    realistic case where the two diverge.
+    """
     return [
-        {"id": "mob1s1a1_member_mwan", "interface": "mob1s1a1", "metric": "1"},
-        {"id": "mob1s2a1_member_mwan", "interface": "mob1s2a1", "metric": "2"},
-        {"id": "wan1_member_mwan", "interface": "wan1", "metric": "3"},
-        {"id": "wan2_member_mwan", "interface": "wan2", "metric": "4"},
+        {
+            "id": "mob1s1a1_member_mwan",
+            "interface": "mob1s1a1",
+            "network_id": "mob1s1a1",
+            "metric": "1",
+        },
+        {
+            "id": "mob1s2a1_member_mwan",
+            "interface": "mob1s2a1",
+            "network_id": "mob1s2a1",
+            "metric": "2",
+        },
+        {
+            "id": "wan1_member_mwan",
+            "interface": "wan1",
+            "network_id": "wan1",
+            "metric": "3",
+        },
+        {
+            "id": "wan2_member_mwan",
+            "interface": "wifi1",
+            "network_id": "wan2",
+            "metric": "4",
+        },
     ]
 
 
@@ -323,10 +350,30 @@ def mock_api(mock_device_info, mock_wan_interfaces) -> AsyncMock:
         "policy_id": "mwan_default",
         "mode": "failover",
         "members": [
-            {"id": "mob1s1a1_member_mwan", "interface": "mob1s1a1", "metric": "1"},
-            {"id": "mob1s2a1_member_mwan", "interface": "mob1s2a1", "metric": "2"},
-            {"id": "wan1_member_mwan", "interface": "wan1", "metric": "3"},
-            {"id": "wan2_member_mwan", "interface": "wan2", "metric": "4"},
+            {
+                "id": "mob1s1a1_member_mwan",
+                "interface": "mob1s1a1",
+                "network_id": "mob1s1a1",
+                "metric": "1",
+            },
+            {
+                "id": "mob1s2a1_member_mwan",
+                "interface": "mob1s2a1",
+                "network_id": "mob1s2a1",
+                "metric": "2",
+            },
+            {
+                "id": "wan1_member_mwan",
+                "interface": "wan1",
+                "network_id": "wan1",
+                "metric": "3",
+            },
+            {
+                "id": "wan2_member_mwan",
+                "interface": "wifi1",
+                "network_id": "wan2",
+                "metric": "4",
+            },
         ],
     }
     api.reboot_modem.return_value = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -228,13 +228,23 @@ def mock_modems() -> list[dict]:
 
 @pytest.fixture
 def mock_failover_members() -> list[dict]:
-    """Return mock failover member data."""
+    """Return mock failover member data (failover-mode policy)."""
     return [
         {"id": "mob1s1a1_member_mwan", "interface": "mob1s1a1", "metric": "1"},
         {"id": "mob1s2a1_member_mwan", "interface": "mob1s2a1", "metric": "2"},
         {"id": "wan1_member_mwan", "interface": "wan1", "metric": "3"},
         {"id": "wan2_member_mwan", "interface": "wan2", "metric": "4"},
     ]
+
+
+@pytest.fixture
+def mock_failover_chain(mock_failover_members) -> dict:
+    """Return a failover-mode active-chain payload."""
+    return {
+        "policy_id": "mwan_default",
+        "mode": "failover",
+        "members": mock_failover_members,
+    }
 
 
 @pytest.fixture
@@ -246,7 +256,7 @@ def mock_rutos_data(
     mock_modem_signal,
     mock_modem_status,
     mock_modems,
-    mock_failover_members,
+    mock_failover_chain,
 ) -> RutOSData:
     """Return a populated RutOSData instance."""
     return RutOSData(
@@ -258,7 +268,7 @@ def mock_rutos_data(
         modem_signal=mock_modem_signal,
         modem_status=mock_modem_status,
         modems=mock_modems,
-        failover_members=mock_failover_members,
+        failover_chain=mock_failover_chain,
     )
 
 
@@ -309,12 +319,16 @@ def mock_api(mock_device_info, mock_wan_interfaces) -> AsyncMock:
         {"id": "modem1", "operator": "T-Mobile", "roaming": False},
     ]
     api.get_modems.return_value = [{"id": "modem1"}]
-    api.get_failover_members.return_value = [
-        {"id": "mob1s1a1_member_mwan", "interface": "mob1s1a1", "metric": "1"},
-        {"id": "mob1s2a1_member_mwan", "interface": "mob1s2a1", "metric": "2"},
-        {"id": "wan1_member_mwan", "interface": "wan1", "metric": "3"},
-        {"id": "wan2_member_mwan", "interface": "wan2", "metric": "4"},
-    ]
+    api.get_active_failover_chain.return_value = {
+        "policy_id": "mwan_default",
+        "mode": "failover",
+        "members": [
+            {"id": "mob1s1a1_member_mwan", "interface": "mob1s1a1", "metric": "1"},
+            {"id": "mob1s2a1_member_mwan", "interface": "mob1s2a1", "metric": "2"},
+            {"id": "wan1_member_mwan", "interface": "wan1", "metric": "3"},
+            {"id": "wan2_member_mwan", "interface": "wan2", "metric": "4"},
+        ],
+    }
     api.reboot_modem.return_value = None
     api.set_interface_enabled.return_value = None
     api.set_failover_order.return_value = None

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -674,14 +674,20 @@ class TestSetFailoverOrder:
     """Tests for set_failover_order."""
 
     async def test_set_failover_order(self, api_client):
-        """Test sets mwan3 member metrics via single bulk PUT."""
+        """Test sets mwan3 member metrics via single bulk PUT.
+
+        The API method now takes pre-resolved member IDs, so the caller is
+        responsible for the member-ID/interface-ID translation (typically via
+        get_active_failover_chain).
+        """
         with aioresponses() as m:
             m.post(_url("/login"), payload=_login_success())
             m.put(_url("/failover/members/config"), payload=_success())
 
-            await api_client.set_failover_order(["wan1", "mob1s1a1"])
+            await api_client.set_failover_order(
+                ["wan1_member_mwan", "mob1s1a1_member_mwan"]
+            )
 
-            # Verify single PUT call with array payload
             put_requests = []
             for key, requests in m.requests.items():
                 if key[0] == "PUT":
@@ -695,6 +701,102 @@ class TestSetFailoverOrder:
                     {"id": "mob1s1a1_member_mwan", "metric": "2"},
                 ]
             }
+
+
+class TestGetActiveFailoverChain:
+    """Tests for get_active_failover_chain."""
+
+    @staticmethod
+    def _failover_setup(
+        m: aioresponses,
+        *,
+        rules: list[dict] | None = None,
+        policies: list[dict] | None = None,
+        members: list[dict] | None = None,
+    ) -> None:
+        """Stub the policies/rules/members endpoints with given payloads."""
+        m.post(_url("/login"), payload=_login_success())
+        m.get(_url("/failover/policies/config"), payload=_success(policies or []))
+        m.get(_url("/failover/rules/config"), payload=_success(rules or []))
+        m.get(_url("/failover/members/config"), payload=_success(members or []))
+
+    async def test_failover_mode_with_default_rule(self, api_client):
+        """Default rule selects the failover policy; mode is 'failover'."""
+        with aioresponses() as m:
+            self._failover_setup(
+                m,
+                rules=[{"id": "default_rule", "name": "default_rule",
+                        "use_policy": "mwan_default"}],
+                policies=[{
+                    "id": "mwan_default", "name": "mwan",
+                    "use_member": ["mob1s1a1_member_mwan", "wan1_member_mwan"],
+                }],
+                members=[
+                    {"id": "mob1s1a1_member_mwan", "interface": "mob1s1a1",
+                     "metric": "1"},
+                    {"id": "wan1_member_mwan", "interface": "wan1", "metric": "2"},
+                ],
+            )
+            chain = await api_client.get_active_failover_chain()
+
+        assert chain["policy_id"] == "mwan_default"
+        assert chain["mode"] == "failover"
+        assert [m["id"] for m in chain["members"]] == [
+            "mob1s1a1_member_mwan",
+            "wan1_member_mwan",
+        ]
+
+    async def test_balance_mode_detected_via_equal_metrics(self, api_client):
+        """Members all sharing one metric => balance mode."""
+        with aioresponses() as m:
+            self._failover_setup(
+                m,
+                rules=[{"id": "default_rule", "name": "default_rule",
+                        "use_policy": "balance_default"}],
+                policies=[{
+                    "id": "balance_default", "name": "balance",
+                    "use_member": [
+                        "mob1s1a1_member_balance", "wan1_member_balance",
+                    ],
+                }],
+                members=[
+                    {"id": "mob1s1a1_member_balance", "interface": "mob1s1a1",
+                     "metric": "1", "weight": "1"},
+                    {"id": "wan1_member_balance", "interface": "wan1",
+                     "metric": "1", "weight": "1"},
+                ],
+            )
+            chain = await api_client.get_active_failover_chain()
+
+        assert chain["mode"] == "balance"
+        assert chain["policy_id"] == "balance_default"
+
+    async def test_no_naming_assumption_in_discovery(self, api_client):
+        """Discovery works regardless of member-ID suffix (regression #38)."""
+        with aioresponses() as m:
+            self._failover_setup(
+                m,
+                rules=[{"id": "rule1", "name": "default_rule",
+                        "use_policy": "p1"}],
+                policies=[{"id": "p1", "name": "p1",
+                           "use_member": ["custom_a", "custom_b"]}],
+                members=[
+                    {"id": "custom_a", "interface": "wan1", "metric": "1"},
+                    {"id": "custom_b", "interface": "mob1", "metric": "2"},
+                ],
+            )
+            chain = await api_client.get_active_failover_chain()
+
+        assert chain["mode"] == "failover"
+        assert [m["interface"] for m in chain["members"]] == ["wan1", "mob1"]
+
+    async def test_empty_when_no_rules_or_policies(self, api_client):
+        """No rules and no policies => empty chain, default failover mode."""
+        with aioresponses() as m:
+            self._failover_setup(m, rules=[], policies=[], members=[])
+            chain = await api_client.get_active_failover_chain()
+
+        assert chain == {"policy_id": None, "mode": "failover", "members": []}
 
 
 class TestPostMethod:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -713,12 +713,16 @@ class TestGetActiveFailoverChain:
         rules: list[dict] | None = None,
         policies: list[dict] | None = None,
         members: list[dict] | None = None,
+        interfaces: list[dict] | None = None,
     ) -> None:
-        """Stub the policies/rules/members endpoints with given payloads."""
+        """Stub the policies/rules/members/interfaces endpoints."""
         m.post(_url("/login"), payload=_login_success())
         m.get(_url("/failover/policies/config"), payload=_success(policies or []))
         m.get(_url("/failover/rules/config"), payload=_success(rules or []))
         m.get(_url("/failover/members/config"), payload=_success(members or []))
+        m.get(
+            _url("/failover/interfaces/config"), payload=_success(interfaces or [])
+        )
 
     async def test_failover_mode_with_default_rule(self, api_client):
         """Default rule selects the failover policy; mode is 'failover'."""
@@ -736,6 +740,10 @@ class TestGetActiveFailoverChain:
                      "metric": "1"},
                     {"id": "wan1_member_mwan", "interface": "wan1", "metric": "2"},
                 ],
+                interfaces=[
+                    {"id": "mob1s1a1", "name": "mob1s1a1"},
+                    {"id": "wan1", "name": "wan1"},
+                ],
             )
             chain = await api_client.get_active_failover_chain()
 
@@ -745,6 +753,59 @@ class TestGetActiveFailoverChain:
             "mob1s1a1_member_mwan",
             "wan1_member_mwan",
         ]
+        assert [m["network_id"] for m in chain["members"]] == ["mob1s1a1", "wan1"]
+
+    async def test_member_interface_resolved_via_mwan_interface_bridge(
+        self, api_client
+    ):
+        """``mwan_member.interface`` is the mwan_interface display name, not its id.
+
+        Regression for #38: when the user customizes the display name (or wifi
+        interfaces, where defaults already differ), ``member.interface`` no
+        longer matches the network UCI id and we have to bridge through
+        ``/failover/interfaces/config`` (``mwan_interface.name`` →
+        ``mwan_interface.id``).
+        """
+        with aioresponses() as m:
+            self._failover_setup(
+                m,
+                rules=[{"id": "default_rule", "name": "default_rule",
+                        "use_policy": "mwan_default"}],
+                policies=[{
+                    "id": "mwan_default", "name": "mwan",
+                    "use_member": ["wan2_member_mwan"],
+                }],
+                members=[
+                    {"id": "wan2_member_mwan", "interface": "wifi1", "metric": "1"},
+                ],
+                interfaces=[
+                    {"id": "wan2", "name": "wifi1"},
+                ],
+            )
+            chain = await api_client.get_active_failover_chain()
+
+        assert chain["members"][0]["interface"] == "wifi1"
+        assert chain["members"][0]["network_id"] == "wan2"
+
+    async def test_member_network_id_none_when_bridge_missing(self, api_client):
+        """``network_id`` is None if no mwan_interface entry matches."""
+        with aioresponses() as m:
+            self._failover_setup(
+                m,
+                rules=[{"id": "default_rule", "name": "default_rule",
+                        "use_policy": "mwan_default"}],
+                policies=[{
+                    "id": "mwan_default", "name": "mwan",
+                    "use_member": ["orphan_member"],
+                }],
+                members=[
+                    {"id": "orphan_member", "interface": "ghost", "metric": "1"},
+                ],
+                interfaces=[],
+            )
+            chain = await api_client.get_active_failover_chain()
+
+        assert chain["members"][0]["network_id"] is None
 
     async def test_balance_mode_detected_via_equal_metrics(self, api_client):
         """Members all sharing one metric => balance mode."""

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -283,6 +283,49 @@ async def test_options_flow_too_few_groups_error(
     assert result["errors"] == {"base": "too_few_groups"}
 
 
+async def test_options_flow_balance_mode_shows_unavailable_step(
+    hass: HomeAssistant, mock_config_entry, mock_api
+):
+    """When the active policy is balance mode, the failover_balance step is shown."""
+    mock_api.get_active_failover_chain.return_value = {
+        "policy_id": "balance_default",
+        "mode": "balance",
+        "members": [
+            {"id": "wan1_member_balance", "interface": "wan1", "metric": "1"},
+            {"id": "mob1s1a1_member_balance", "interface": "mob1s1a1",
+             "metric": "1"},
+        ],
+    }
+    mock_config_entry.add_to_hass(hass)
+
+    with patch("custom_components.rutos.RutOSAPI", return_value=mock_api):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        result = await hass.config_entries.options.async_init(
+            mock_config_entry.entry_id
+        )
+        # Step 1: init still shown so the user can update general settings.
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={CONF_UPDATE_HOME_LOCATION: True},
+        )
+        # Step 2: failover_balance informational step (no fields).
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "failover_balance"
+
+        # Submitting completes the flow without setting any new groups.
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={}
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert mock_config_entry.options[CONF_UPDATE_HOME_LOCATION] is True
+    # Existing failover groups (none) are preserved.
+    assert mock_config_entry.options.get(CONF_FAILOVER_GROUPS, {}) == {}
+
+
 # ---------------------------------------------------------------------------
 # Recipient subentry flow tests
 # ---------------------------------------------------------------------------

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -78,8 +78,18 @@ def mock_api_instance():
         "policy_id": "mwan_default",
         "mode": "failover",
         "members": [
-            {"id": "wan_member_mwan", "interface": "wan", "metric": "1"},
-            {"id": "mob1s1a1_member_mwan", "interface": "mob1s1a1", "metric": "2"},
+            {
+                "id": "wan_member_mwan",
+                "interface": "wan",
+                "network_id": "wan",
+                "metric": "1",
+            },
+            {
+                "id": "mob1s1a1_member_mwan",
+                "interface": "mob1s1a1",
+                "network_id": "mob1s1a1",
+                "metric": "2",
+            },
         ],
     }
     api.set_failover_order.return_value = None

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -72,7 +72,16 @@ def mock_api_instance():
     api.get_gps_position.return_value = None
     api.get_data_limit.return_value = []
     api.get_modem_signal.return_value = []
+    api.get_modem_status.return_value = []
     api.get_modems.return_value = []
+    api.get_active_failover_chain.return_value = {
+        "policy_id": "mwan_default",
+        "mode": "failover",
+        "members": [
+            {"id": "wan_member_mwan", "interface": "wan", "metric": "1"},
+            {"id": "mob1s1a1_member_mwan", "interface": "mob1s1a1", "metric": "2"},
+        ],
+    }
     api.set_failover_order.return_value = None
     return api
 
@@ -136,7 +145,7 @@ async def test_set_failover_order_service_registered(
 async def test_set_failover_order_service_call(
     hass: HomeAssistant, mock_api_instance: AsyncMock
 ):
-    """Test service call invokes API and triggers refresh."""
+    """Test service call resolves interfaces to member IDs, invokes API, refreshes."""
     entry = _create_entry(hass)
 
     with patch("custom_components.rutos.RutOSAPI", return_value=mock_api_instance):
@@ -150,7 +159,42 @@ async def test_set_failover_order_service_call(
         blocking=True,
     )
 
-    mock_api_instance.set_failover_order.assert_awaited_once_with(["wan", "mob1s1a1"])
+    # Service translates interface IDs to member IDs from the active policy.
+    mock_api_instance.set_failover_order.assert_awaited_once_with(
+        ["wan_member_mwan", "mob1s1a1_member_mwan"]
+    )
+
+
+async def test_set_failover_order_service_balance_mode_errors(
+    hass: HomeAssistant, mock_api_instance: AsyncMock
+):
+    """Service raises ServiceValidationError when active policy is balance."""
+    from homeassistant.exceptions import ServiceValidationError
+
+    mock_api_instance.get_active_failover_chain.return_value = {
+        "policy_id": "balance_default",
+        "mode": "balance",
+        "members": [
+            {"id": "wan_member_balance", "interface": "wan", "metric": "1"},
+            {"id": "mob1s1a1_member_balance", "interface": "mob1s1a1",
+             "metric": "1"},
+        ],
+    }
+    entry = _create_entry(hass)
+
+    with patch("custom_components.rutos.RutOSAPI", return_value=mock_api_instance):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    with pytest.raises(ServiceValidationError, match="load-balance"):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_FAILOVER_ORDER,
+            {ATTR_INTERFACES: ["wan", "mob1s1a1"]},
+            blocking=True,
+        )
+
+    mock_api_instance.set_failover_order.assert_not_awaited()
 
 
 async def test_register_services_idempotent(

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -17,8 +17,15 @@ GROUPS = {
 
 
 def _chain(members: list[dict], mode: str = "failover") -> dict:
-    """Build an active-failover-chain dict for tests."""
-    return {"policy_id": "mwan_default", "mode": mode, "members": members}
+    """Build an active-failover-chain dict for tests.
+
+    Defaults each member's ``network_id`` to its ``interface`` value so legacy
+    tests (where the two coincide) don't need to spell it out.
+    """
+    enriched = [
+        {**m, "network_id": m.get("network_id", m.get("interface"))} for m in members
+    ]
+    return {"policy_id": "mwan_default", "mode": mode, "members": enriched}
 
 
 class TestRutOSFailoverSelect:

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -16,6 +16,11 @@ GROUPS = {
 }
 
 
+def _chain(members: list[dict], mode: str = "failover") -> dict:
+    """Build an active-failover-chain dict for tests."""
+    return {"policy_id": "mwan_default", "mode": mode, "members": members}
+
+
 class TestRutOSFailoverSelect:
     """Tests for the failover priority select entity."""
 
@@ -29,43 +34,52 @@ class TestRutOSFailoverSelect:
 
     def test_current_option_cellular_first(self, mock_coordinator):
         """Test current_option when cellular has lowest metric."""
-        mock_coordinator.data.failover_members = [
-            {"interface": "mob1s1a1", "metric": "1"},
-            {"interface": "mob1s2a1", "metric": "2"},
-            {"interface": "wan1", "metric": "3"},
-            {"interface": "wan2", "metric": "4"},
-        ]
+        mock_coordinator.data.failover_chain = _chain(
+            [
+                {"id": "mob1s1a1_member_mwan", "interface": "mob1s1a1", "metric": "1"},
+                {"id": "mob1s2a1_member_mwan", "interface": "mob1s2a1", "metric": "2"},
+                {"id": "wan1_member_mwan", "interface": "wan1", "metric": "3"},
+                {"id": "wan2_member_mwan", "interface": "wan2", "metric": "4"},
+            ]
+        )
         entity = RutOSFailoverSelect(mock_coordinator, GROUPS)
         assert entity.current_option == "Cellular, Starlink, WiFi"
 
     def test_current_option_starlink_first(self, mock_coordinator):
         """Test current_option when starlink has lowest metric."""
-        mock_coordinator.data.failover_members = [
-            {"interface": "wan1", "metric": "1"},
-            {"interface": "mob1s1a1", "metric": "2"},
-            {"interface": "mob1s2a1", "metric": "3"},
-            {"interface": "wan2", "metric": "4"},
-        ]
+        mock_coordinator.data.failover_chain = _chain(
+            [
+                {"id": "wan1_member_mwan", "interface": "wan1", "metric": "1"},
+                {"id": "mob1s1a1_member_mwan", "interface": "mob1s1a1", "metric": "2"},
+                {"id": "mob1s2a1_member_mwan", "interface": "mob1s2a1", "metric": "3"},
+                {"id": "wan2_member_mwan", "interface": "wan2", "metric": "4"},
+            ]
+        )
         entity = RutOSFailoverSelect(mock_coordinator, GROUPS)
         assert entity.current_option == "Starlink, Cellular, WiFi"
 
     def test_current_option_none_when_missing_interface(self, mock_coordinator):
         """Test current_option returns None when interface is missing."""
-        mock_coordinator.data.failover_members = [
-            {"interface": "mob1s1a1", "metric": "1"},
-        ]
+        mock_coordinator.data.failover_chain = _chain(
+            [{"id": "mob1s1a1_member_mwan", "interface": "mob1s1a1", "metric": "1"}]
+        )
         entity = RutOSFailoverSelect(mock_coordinator, GROUPS)
         assert entity.current_option is None
 
     @pytest.mark.asyncio
     async def test_select_option_expands_groups(self, mock_coordinator):
-        """Test that selecting an option expands groups into interface list."""
+        """Test that selecting an option resolves member IDs from the active policy."""
         mock_coordinator.async_request_refresh = AsyncMock()
         entity = RutOSFailoverSelect(mock_coordinator, GROUPS)
         await entity.async_select_option("Starlink, Cellular, WiFi")
 
         mock_coordinator.api.set_failover_order.assert_awaited_once_with(
-            ["wan1", "mob1s1a1", "mob1s2a1", "wan2"]
+            [
+                "wan1_member_mwan",
+                "mob1s1a1_member_mwan",
+                "mob1s2a1_member_mwan",
+                "wan2_member_mwan",
+            ]
         )
         mock_coordinator.async_request_refresh.assert_awaited_once()
 
@@ -105,3 +119,28 @@ class TestRutOSFailoverSelect:
         assert len(entity.options) == 2
         assert "Cellular, Starlink" in entity.options
         assert "Starlink, Cellular" in entity.options
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_skips_in_balance_mode(hass, mock_coordinator):
+    """Test that no entity is created when the active policy is balance mode."""
+    from custom_components.rutos.const import CONF_FAILOVER_GROUPS
+    from custom_components.rutos.select import async_setup_entry
+
+    mock_coordinator.data.failover_chain = _chain(
+        [
+            {"id": "wan1_member_balance", "interface": "wan1", "metric": "1"},
+            {"id": "mob1s1a1_member_balance", "interface": "mob1s1a1", "metric": "1"},
+        ],
+        mode="balance",
+    )
+
+    entry = AsyncMock()
+    entry.options = {
+        CONF_FAILOVER_GROUPS: {"Cellular": ["mob1s1a1"], "Starlink": ["wan1"]}
+    }
+    entry.runtime_data = mock_coordinator
+    add_entities = AsyncMock()
+
+    await async_setup_entry(hass, entry, add_entities)
+    add_entities.assert_not_called()

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -120,6 +120,41 @@ class TestRutOSFailoverSelect:
         assert "Cellular, Starlink" in entity.options
         assert "Starlink, Cellular" in entity.options
 
+    def test_unavailable_when_mode_flips_to_balance(self, mock_coordinator):
+        """Entity becomes unavailable if the router switches to balance mode at runtime."""
+        entity = RutOSFailoverSelect(mock_coordinator, GROUPS)
+        assert entity.available is True
+
+        mock_coordinator.data.failover_chain = _chain(
+            [
+                {"id": "mob1s1a1_member_balance", "interface": "mob1s1a1",
+                 "metric": "1"},
+                {"id": "wan1_member_balance", "interface": "wan1", "metric": "1"},
+            ],
+            mode="balance",
+        )
+        assert entity.available is False
+
+    @pytest.mark.asyncio
+    async def test_select_option_raises_in_balance_mode(self, mock_coordinator):
+        """async_select_option raises HomeAssistantError if mode is balance."""
+        from homeassistant.exceptions import HomeAssistantError
+
+        entity = RutOSFailoverSelect(mock_coordinator, GROUPS)
+        mock_coordinator.data.failover_chain = _chain(
+            [
+                {"id": "mob1s1a1_member_balance", "interface": "mob1s1a1",
+                 "metric": "1"},
+                {"id": "wan1_member_balance", "interface": "wan1", "metric": "1"},
+            ],
+            mode="balance",
+        )
+
+        with pytest.raises(HomeAssistantError, match="load-balance"):
+            await entity.async_select_option("Cellular, Starlink, WiFi")
+
+        mock_coordinator.api.set_failover_order.assert_not_awaited()
+
 
 @pytest.mark.asyncio
 async def test_async_setup_entry_skips_in_balance_mode(hass, mock_coordinator):


### PR DESCRIPTION
## Summary
- Discovery now reads the active mwan3 policy (resolved via `/failover/rules/config`) and uses its `use_member` array as the source of truth, rather than filtering by the `_member_mwan` name suffix. Fixes #38 on RUTC50 and any firmware where member naming differs.
- Detect load-balance vs failover mode from member metrics (equal metrics => balance). In balance mode: hide the Failover priority entity, replace the failover-groups config-flow step with an informational "unavailable" step, and have the `set_failover_order` service raise `ServiceValidationError`.
- Write path unchanged. Empirical capture against the test router confirmed the GUI sets priority by mutating member metrics, not by reordering policy `use_member`. The integration's `set_failover_order` already does this; only its input format changes (now takes pre-resolved member IDs).

## Test plan
- [x] 220 unit tests pass (`.venv/bin/python -m pytest tests/`)
- [x] `ruff check`, `ruff format --check`, `pyright` clean
- [x] Live exercise against `.env`-configured test router: `get_active_failover_chain()` returns the expected failover-mode chain with `mwan_default` policy
- [ ] Confirm on RUTC50 (issue reporter) that the failover groups form now renders interface fields
- [ ] In HA: changing the Failover priority select rewrites router metrics correctly
- [ ] In HA: with the router's default rule pointed at a balance policy, the Failover priority entity disappears and the config flow shows the "Failover priority unavailable" step

🤖 Generated with [Claude Code](https://claude.com/claude-code)